### PR TITLE
Bump NW.js to 0.69.1

### DIFF
--- a/build.conf
+++ b/build.conf
@@ -2,7 +2,7 @@
 	"outputDirectory": "./bin",
 	"cacheDirectory": "./bin/_cache",
 	"sourceDirectory": "./src",
-	"webkitVersion": "0.48.4",
+	"webkitVersion": "0.69.1",
 	"webkitURL": "https://dl.nwjs.io/v%s/%s",
 	"manifest": {
 		"name": "wow.export",


### PR DESCRIPTION
Needs some more testing of the stuff I don't understand (e.g. the remote control thing) and possibly some bumping of Node version numbers somewhere seeing NW.js is now on Node [v18.10.0](https://nwjs.io/blog/v0.69.1/).