### PR TITLE
build on macos and linux platform

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -89,7 +89,7 @@ try {
 		default: console.log("Unsupported platform");
 		break;
 	}
-	const buildDir = path.join('bin', isDebugBuild ? platform + '-debug' : platform);
+	const buildDir = path.join('bin', is Debug Build ? 'win-x64-debug' : 'win-x64' );
 	log.info('Building {%s} in {%s}...', buildType, path.resolve(buildDir));
 
 	// If --code is set, update the code files in the build directory.

--- a/build.ts
+++ b/build.ts
@@ -68,8 +68,8 @@ try {
 
 	const isDebugBuild = argv.includes('--debug');
 	const buildType = isDebugBuild ? 'development' : 'production';
-	let platform: string = 'null' ;
-	let extension: string = 'null' ;
+	let platform: string = '';
+	let extension: string = '';
 	switch(process.platform) {
 		case 'darwin': {
 			platform = 'macos';

--- a/build.ts
+++ b/build.ts
@@ -82,12 +82,13 @@ try {
 		}
 		break;
 		case 'win32': {
-			platform = 'windows';
+			platform = 'win-x64';
 			extension = '.exe' ;
 		}
 		break;
+		default: console.log("Unsupported platform");
+		break;
 	}
-
 	const buildDir = path.join('bin', isDebugBuild ? platform + '-debug' : platform);
 	log.info('Building {%s} in {%s}...', buildType, path.resolve(buildDir));
 

--- a/build.ts
+++ b/build.ts
@@ -89,7 +89,7 @@ try {
 		default: console.log("Unsupported platform");
 		break;
 	}
-	const buildDir = path.join('bin', is Debug Build ? 'win-x64-debug' : 'win-x64' );
+	const buildDir = path.join('bin', isDebugBuild ? 'win-x64-debug' : 'win-x64' );
 	log.info('Building {%s} in {%s}...', buildType, path.resolve(buildDir));
 
 	// If --code is set, update the code files in the build directory.

--- a/build.ts
+++ b/build.ts
@@ -72,12 +72,12 @@ try {
 	let extension: string = '';
 	switch(process.platform) {
 		case 'darwin': {
-			platform = 'macos';
+			platform = 'macos-x64';
 			extension = '.app';
 		}
 		break;
 		case 'linux': {
-			platform = 'linux';
+			platform = 'linux-x64';
 			extension = '';
 		}
 		break;
@@ -148,7 +148,7 @@ try {
 		// Step 4: Build nw.js distribution using `nwjs-installer'.
 		// See https://github.com/Kruithne/nwjs-installer for usage information.
 		log.info('Running {nwjs-installer}...');
-		execute_command('nwjs-installer --target-dir "%s" --version 0.75.0 --platform ' + platform + ' --arch x64 --remove-pak-info --locale en-US --exclude "^notification_helper.exe$"' + (isDebugBuild ? ' --sdk' : ''), buildDir);
+		execute_command('nwjs-installer --target-dir "%s" --version 0.75.0 --platform win --arch x64 --remove-pak-info --locale en-US --exclude "^notification_helper.exe$"' + (isDebugBuild ? ' --sdk' : ''), buildDir);
 
 		// Step 4: Copy and adjust the package manifest.
 		log.info('Generating {package.json} for distribution...');

--- a/build.ts
+++ b/build.ts
@@ -7,7 +7,7 @@ import zlib from 'node:zlib';
 import util from 'node:util';
 import path from 'node:path';
 import fs from 'node:fs';
-import process from 'node:process' ;
+import fs from 'node:fs';
 
 const INCLUDE = {
 	'LICENSE': 'license/LICENSE',
@@ -68,23 +68,14 @@ try {
 
 	const isDebugBuild = argv.includes('--debug');
 	const buildType = isDebugBuild ? 'development' : 'production';
-	let platform: string = '';
 	let extension: string = '';
-	switch(process.platform) {
-		case 'darwin': {
-			platform = 'macos-x64';
-			extension = '.app';
-		}
+	
+	switch () {
+		case 'macos': extension = '.app';
 		break;
-		case 'linux': {
-			platform = 'linux-x64';
-			extension = '';
-		}
+		case 'linux': 
 		break;
-		case 'win32': {
-			platform = 'win-x64';
-			extension = '.exe' ;
-		}
+		case 'win': extension = '.exe';
 		break;
 		default: console.log("Unsupported platform");
 		break;


### PR DESCRIPTION
For now, we can only build on Windows platform, the output dir and binaries are harcoded.

Create binaries and output according the build host