### PR TITLE
Redownload DBDs with PH fields (fixes #297)

### DIFF
--- a/src/app/db/WDCReader.ts
+++ b/src/app/db/WDCReader.ts
@@ -188,8 +188,20 @@ export default class WDCReader {
 		if (rawDbd !== null)
 			structure = new DBDParser(rawDbd).getStructure(buildID, layoutHash);
 
-		// No cached definition, download updated DBD and check again.
+		let forceDownload = false;
 		if (structure === null) {
+			// No definition, force redownload
+			forceDownload = true;
+		} else {
+			// If definition has placeholder fields, force redownload
+			for (const field of structure.fields) {
+				if (field.name.startsWith('Field_'))
+					forceDownload = true;
+			}
+		}
+
+		// Download updated DBD and check again.
+		if (forceDownload) {
 			try {
 				const dbdUrl = util.format(State.state.config.dbdURL, tableName);
 				Log.write('No cached DBD, downloading new from %s', dbdUrl);

--- a/src/app/db/WDCReader.ts
+++ b/src/app/db/WDCReader.ts
@@ -188,11 +188,8 @@ export default class WDCReader {
 		if (rawDbd !== null)
 			structure = new DBDParser(rawDbd).getStructure(buildID, layoutHash);
 
-		let forceDownload = false;
-		if (structure === null) {
-			// No definition, force redownload
-			forceDownload = true;
-		} else {
+		let forceDownload = structure === null;
+		if (structure !== null) {
 			// If definition has placeholder fields, force redownload
 			for (const field of structure.fields) {
 				if (field.name.startsWith('Field_'))


### PR DESCRIPTION
This will always redownload DBDs if the currently detected DBD structure for the loaded build has a placeholder field as we currently cache DBDs indefinitely if it has a definition for a given build, regardless of completeness.

Note that this will increase the amount of downloads happening (sometimes each time a DB2 is opened with a DBD that has a long-term placeholder field somewhere). 