### PR TITLE
Update development docs to include dependency for release builds

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -27,6 +27,19 @@ Before you start developing wow.export, you will need to set-up your environment
   - `git clone`
 - Step 5: Install dependencies:
   - `bun install`
+ 
+### Additional dependencies for release builds 
+For building a release build, additional dependency is required.
+
+- Step 1: Install [V Programming Language Compiler](https://github.com/vlang/v/blob/master/doc/docs.md#installing-v-from-source)
+  - ```bash
+       git clone https://github.com/vlang/v
+       cd v
+       make```
+- Step 2: Add V into your PATH per [V documentation](https://github.com/vlang/v/blob/master/README.md#symlinking)
+  - `sudo ./v symlink`
+
+
 
 ## Linting
 wow.export uses [ESLint](https://eslint.org/) to enforce code style and best practices. While not required, it is highly recommended that you install an [ESLint plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for your editor of choice.


### PR DESCRIPTION
There's a missing documentation regarding V lang to be installed as a dependency in the development documentation when building release build. V lang is required for the updater to be compiled.