### PR TITLE
fix typos and spelling errors

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -176,7 +176,7 @@ if (argv.includes('--framework')) {
 // If --package is set, package the build into a ZIP file.
 // Packages are generated to /bin/packages/*
 if (argv.includes('--package')) {
-	// Step 9: Pacakge build into a ZIP file.
+	// Step 9: Package build into a ZIP file.
 	const packageDir = path.join('bin', 'packages');
 	if (!fs.existsSync(packageDir))
 		fs.mkdirSync(packageDir, { recursive: true });

--- a/src/app/3D/loaders/WMOLoader.ts
+++ b/src/app/3D/loaders/WMOLoader.ts
@@ -218,7 +218,7 @@ export class WMOLoader {
 	}
 
 	/**
-	 * Read a position, corrected from WoW's co-ordinate system.
+	 * Read a position, corrected from WoW's coordinate system.
 	 */
 	readPosition(): Array<number> {
 		const x = this.data.readFloat();

--- a/src/app/casc/blte-reader.ts
+++ b/src/app/casc/blte-reader.ts
@@ -133,7 +133,7 @@ export default class BLTEReader extends BufferWrapper {
 		}
 
 		this.buffer = Buffer.alloc(allocSize);
-		this.processAllBlocks(); // NIT: We no longer have bounds checking, so we just read all blocks for now. This means things like encoding decoding will take longer than neccesary, but shouldn't affect a lot outside of that.
+		this.processAllBlocks(); // NIT: We no longer have bounds checking, so we just read all blocks for now. This means things like encoding decoding will take longer than necessary, but shouldn't affect a lot outside of that.
 	}
 
 	/**

--- a/src/app/casc/tact-keys.ts
+++ b/src/app/casc/tact-keys.ts
@@ -118,7 +118,7 @@ export async function load(): Promise<void> {
 }
 
 /**
- * Asyncronously save tact keys to disk.
+ * Asynchronously save tact keys to disk.
  */
 export async function save(): Promise<void> {
 	if (!isSaving) {

--- a/src/app/components/itemlistbox.ts
+++ b/src/app/components/itemlistbox.ts
@@ -93,7 +93,7 @@ export default defineComponent({
 
 		/**
 		 * Index which array reading should start at, based on the current
-		 * relative scroll and the overal item count. Value is dynamically
+		 * relative scroll and the overall item count. Value is dynamically
 		 * capped based on slot count to prevent empty slots appearing.
 		 */
 		scrollIndex: function(): number {

--- a/src/app/components/listbox.ts
+++ b/src/app/components/listbox.ts
@@ -118,7 +118,7 @@ export default defineComponent({
 
 		/**
 		 * Index which array reading should start at, based on the current
-		 * relative scroll and the overal item count. Value is dynamically
+		 * relative scroll and the overall item count. Value is dynamically
 		 * capped based on slot count to prevent empty slots appearing.
 		 */
 		scrollIndex: function(): number {

--- a/src/app/components/listboxb.ts
+++ b/src/app/components/listboxb.ts
@@ -78,7 +78,7 @@ export default defineComponent({
 
 		/**
 		 * Index which array reading should start at, based on the current
-		 * relative scroll and the overal item count. Value is dynamically
+		 * relative scroll and the overall item count. Value is dynamically
 		 * capped based on slot count to prevent empty slots appearing.
 		 */
 		scrollIndex: function(): number {

--- a/src/app/components/map-viewer.ts
+++ b/src/app/components/map-viewer.ts
@@ -217,7 +217,7 @@ export default defineComponent({
 					const index = this.mask.findIndex((e: number) => e === 1);
 
 					if (index > -1) {
-						// Translate the index into chunk co-ordinates, expand those to in-game co-ordinates
+						// Translate the index into chunk coordinates, expand those to in-game coordinates
 						// and then offset by half a chunk so that we are centered on the chunk.
 						const chunkX = index % Constants.GAME.MAP_SIZE;
 						const chunkY = Math.floor(index / Constants.GAME.MAP_SIZE);
@@ -470,7 +470,7 @@ export default defineComponent({
 		 * @param y
 		 */
 		setMapPosition: function(x: number, y: number): void {
-			// Translate to WoW co-ordinates.
+			// Translate to WoW coordinates.
 			const posX = y;
 			const posY = x;
 

--- a/src/app/png-writer.ts
+++ b/src/app/png-writer.ts
@@ -215,7 +215,7 @@ const paeth = (left: number, up: number, upLeft: number): number => {
 };
 
 /**
- * Apply adapative filtering to RGBA data.
+ * Apply adaptive filtering to RGBA data.
  * @param data - The data to filter.
  * @param width - The width of the image.
  * @param height - The height of the image.


### PR DESCRIPTION
Fixing some minor typos and spelling errors which should not affect functionality but improve the overall quality of documentation.