### PR TITLE
Add WMO and m2 tags for model objects

### DIFF
--- a/src/js/3D/exporters/M2Exporter.js
+++ b/src/js/3D/exporters/M2Exporter.js
@@ -286,6 +286,7 @@ class M2Exporter {
 				}, texture);
 			}
 
+			json.addProperty('fileType', 'm2');
 			json.addProperty('fileDataID', this.fileDataID);
 			json.addProperty('fileName', listfile.getByID(this.fileDataID));
 			json.addProperty('internalName', this.m2.name);

--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -583,6 +583,7 @@ class WMOExporter {
 			helper.setCurrentTaskName(wmoName + ', writing meta data');
 
 			const json = new JSONWriter(ExportHelper.replaceExtension(out, '.json'));
+			json.addProperty('fileType', 'wmo');
 			json.addProperty('fileDataID', wmo.fileDataID);
 			json.addProperty('fileName', wmo.fileName);
 			json.addProperty('version', wmo.version);


### PR DESCRIPTION
This will allow the json parsers to know exactly what type of metadata to expect and process.

Currently not able to test this since the builds aren't completing, but it's a straight-forward change.