### PR TITLE
Somewhat fix gltf exporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # IDE configuration.
 /.vscode
+/.idea
 
 # Compiled stylesheets (use .scss for source).
 *.css

--- a/src/js/3D/exporters/M2Exporter.js
+++ b/src/js/3D/exporters/M2Exporter.js
@@ -172,7 +172,7 @@ class M2Exporter {
 		gltf.setNormalArray(this.m2.normals);
 		gltf.setUVArray(this.m2.uv);
 		gltf.setBoneWeightArray(this.m2.boneWeights);
-		gltf.setBoneIndiceArray(this.m2.boneIndices)
+		gltf.setBoneIndexArray(this.m2.boneIndices)
 		gltf.setBonesArray(this.m2.bones);
 
 		// TODO: Handle UV2 for GLTF.

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -9,7 +9,6 @@ const path = require('path');
 const generics = require('../../generics');
 const ExportHelper = require('../../casc/export-helper');
 const BufferWrapper = require('../../buffer');
-const { Euler, Quaternion } = require("../../../lib/three");
 
 class GLTFWriter {
 	/**
@@ -140,11 +139,6 @@ class GLTFWriter {
 			nodes: [
 				{
 					name: this.name,
-					rotation: (() => {
-						let q = new Quaternion();
-						q.setFromEuler(new Euler(-Math.PI / 2, 0, 0));
-						return [q.x, q.y, q.z, q.w];
-					})(),
 					children: [],
 				}
 			],

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -235,7 +235,7 @@ class GLTFWriter {
 			],
 			skins: [
 				{
-					name: this.name,
+					name: this.name + "_Armature",
 					joints: [],
 					skeleton: 0
 				}
@@ -251,7 +251,7 @@ class GLTFWriter {
 		const skin = root.skins[0];
 
 		const bones = this.bones;
-		const armature = root.nodes[0];
+		const skeleton = nodes[0];
 
 		// Bone child lookup.
 		for (let i = 0; i < bones.length; i++) {
@@ -263,7 +263,7 @@ class GLTFWriter {
 				parent.children ? parent.children.push(nodeIndex) : parent.children = [nodeIndex];
 			} else {
 				// Parent stray bones to the skeleton root.
-				armature.children.push(nodeIndex);
+				skeleton.children.push(nodeIndex);
 			}
 		}
 
@@ -393,7 +393,7 @@ class GLTFWriter {
 
 			//const nodeIndex = nodes.length;
 			//rootChildren.push(nodeIndex);
-			nodes.push({ name: mesh.name, mesh: meshIndex, skin: 0 });
+			nodes.push({ name: `${this.name}_${mesh.name}`, mesh: meshIndex, skin: 0 });
 		}
 
 		await generics.createDirectory(path.dirname(this.out));

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -10,6 +10,24 @@ const generics = require('../../generics');
 const ExportHelper = require('../../casc/export-helper');
 const BufferWrapper = require('../../buffer');
 
+const GLTF_ARRAY_BUFFER = 0x8892;
+const GLTF_ELEMENT_ARRAY_BUFFER = 0x8893;
+
+//const GLTF_BYTE = 0x1400;
+const GLTF_UNSIGNED_BYTE = 0x1401;
+//const GLTF_SHORT = 0x1402;
+const GLTF_UNSIGNED_SHORT = 0x1403;
+//const GLTF_UNSIGNED_INT = 0x1405;
+const GLTF_FLOAT = 0x1406;
+
+//const GLTF_POINTS = 0x0000;
+//const GLTF_LINES = 0x0001;
+//const GLTF_LINE_LOOP = 0x0002;
+//const GLTF_LINE_STRIP = 0x0003;
+const GLTF_TRIANGLES = 0x0004;
+//const GLTF_TRIANGLE_STRIP = 0x0005;
+//const GLTF_TRIANGLE_FAN = 0x0006;
+
 class GLTFWriter {
 	/**
 	 * Construct a new GLTF writer instance.
@@ -160,35 +178,35 @@ class GLTFWriter {
 					buffer: 0,
 					byteLength: 0,
 					byteOffset: 0,
-					target: 0x8892
+					target: GLTF_ARRAY_BUFFER
 				},
 				{
 					// Normals ARRAY_BUFFER
 					buffer: 0,
 					byteLength: 0,
 					byteOffset: 0,
-					target: 0x8892
+					target: GLTF_ARRAY_BUFFER
 				},
 				{
 					// UVs ARRAY_BUFFER
 					buffer: 0,
 					byteLength: 0,
 					byteOffset: 0,
-					target: 0x8892
+					target: GLTF_ARRAY_BUFFER
 				},
 				{
 					// Bone joints/indices ARRAY_BUFFER
 					buffer: 0,
 					byteLength: 0,
 					byteOffset: 0,
-					target: 0x8892
+					target: GLTF_ARRAY_BUFFER
 				},
 				{
 					// Bone weights ARRAY_BUFFER
 					buffer: 0,
 					byteLength: 0,
 					byteOffset: 0,
-					target: 0x8892
+					target: GLTF_ARRAY_BUFFER
 				}
 			],
 			accessors: [
@@ -196,7 +214,7 @@ class GLTFWriter {
 					// Vertices (Float)
 					bufferView: 0,
 					byteOffset: 0,
-					componentType: 0x1406,
+					componentType: GLTF_FLOAT,
 					count: 0,
 					type: 'VEC3'
 				},
@@ -204,7 +222,7 @@ class GLTFWriter {
 					// Normals (Float)
 					bufferView: 1,
 					byteOffset: 0,
-					componentType: 0x1406,
+					componentType: GLTF_FLOAT,
 					count: 0,
 					type: 'VEC3'
 				},
@@ -212,7 +230,7 @@ class GLTFWriter {
 					// UVs (Float)
 					bufferView: 2,
 					byteOffset: 0,
-					componentType: 0x1406,
+					componentType: GLTF_FLOAT,
 					count: 0,
 					type: 'VEC2'
 				},
@@ -220,7 +238,7 @@ class GLTFWriter {
 					// Bone joints/indices (Byte)
 					bufferView: 3,
 					byteOffset: 0,
-					componentType: 0x1401,
+					componentType: GLTF_UNSIGNED_BYTE,
 					count: 0,
 					type: 'VEC4'
 				},
@@ -228,7 +246,7 @@ class GLTFWriter {
 					// Bone weights (Byte)
 					bufferView: 4,
 					byteOffset: 0,
-					componentType: 0x1401,
+					componentType: GLTF_UNSIGNED_BYTE,
 					count: 0,
 					type: 'VEC4'
 				}
@@ -326,27 +344,27 @@ class GLTFWriter {
 
 			view.byteOffset = bin.offset;
 
-			if (componentType === 0x1406)
+			if (componentType === GLTF_FLOAT)
 				view.byteLength = arr.length * 4;
-			else if (componentType === 0x1401)
+			else if (componentType === GLTF_UNSIGNED_BYTE)
 				view.byteLength = arr.length;
 
 			accessor.count = arr.length / stride;
 
 			this.calculateMinMax(arr, stride, accessor);
 			for (const node of arr) {
-				if (componentType === 0x1406)
+				if (componentType === GLTF_FLOAT)
 					bin.writeFloatLE(node);
-				else if (componentType === 0x1401)
+				else if (componentType === GLTF_UNSIGNED_BYTE)
 					bin.writeUInt8(node);
 			}
 		};
 
-		writeData(0, this.vertices, 3, 0x1406);
-		writeData(1, this.normals, 3, 0x1406);
-		writeData(2, this.uvs, 2, 0x1406);
-		writeData(3, this.boneIndices, 4, 0x1401);
-		writeData(4, this.boneWeights, 4, 0x1401);
+		writeData(0, this.vertices, 3, GLTF_FLOAT);
+		writeData(1, this.normals, 3, GLTF_FLOAT);
+		writeData(2, this.uvs, 2, GLTF_FLOAT);
+		writeData(3, this.boneIndices, 4, GLTF_UNSIGNED_BYTE);
+		writeData(4, this.boneWeights, 4, GLTF_UNSIGNED_BYTE);
 
 		for (const mesh of this.meshes) {
 			const bufferViewIndex = root.bufferViews.length;
@@ -357,14 +375,14 @@ class GLTFWriter {
 				buffer: 0,
 				byteLength: mesh.triangles.length * 2,
 				byteOffset: bin.offset,
-				target: 0x8893
+				target: GLTF_ELEMENT_ARRAY_BUFFER
 			});
 
 			// Create accessor for the mesh indices.
 			root.accessors.push({
 				bufferView: bufferViewIndex,
 				byteOffset: 0,
-				componentType: 0x1403,
+				componentType: GLTF_UNSIGNED_SHORT,
 				count: mesh.triangles.length,
 				type: 'SCALAR'
 			});
@@ -385,7 +403,7 @@ class GLTFWriter {
 							WEIGHTS_0: 4,
 						},
 						indices: accessorIndex,
-						mode: 4,
+						mode: GLTF_TRIANGLES,
 						material: materialMap.get(mesh.matName)
 					}
 				]

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -320,7 +320,7 @@ class GLTFWriter {
 
 		// Flip UV on Y axis.
 		for (let i = 0, n = this.uvs.length; i < n; i += 2)
-			this.uvs[i + 1] *= -1;
+			this.uvs[i + 1] = (this.uvs[i + 1] - 1) * -1;
 
 		const binSize = (this.vertices.length * 4) + (this.normals.length * 4) + (this.uvs.length * 4) + this.boneIndices.length + this.boneWeights.length + triangleSize;
 		const bin = BufferWrapper.alloc(binSize, false);

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -138,8 +138,8 @@ const view = {
 	],
 	menuButtonModels: [
 		{ label: 'Export OBJ', value: 'OBJ' },
-		//{ label: 'Export glTF', value: 'GLTF' },
-		//{ label: 'Export glTF (Binary)', value: 'GLB' },
+		{ label: 'Export glTF', value: 'GLTF' },
+		{ label: 'Export glTF (Binary)', value: 'GLB' },
 		{ label: 'Export M2 / WMO (Raw)', value: 'RAW' },
 		{ label: 'Export PNG (3D Preview)', value: 'PNG' },
 		{ label: 'Copy to Clipboard (3D Preview)', value: 'CLIPBOARD' },


### PR DESCRIPTION
This PR attempts to fix some of the issues with exporting models with armatures to glTF. Currently, models appear oddly distorted but the rigging appears to be correct.

![dragon_armature](https://github.com/Kruithne/wow.export/assets/24487843/fe388416-7e72-4276-8ab7-42534a1d23b8)

Major changes:

- When importing m2 vertices, the `boneWeights` and `boneIndices` arrays had an off-by-one error in their stride. Each vertex has 4 of those values but the code inserted them into the new arrays as if they had 3 values, resulting in each subsequent vertex overwriting the previous vertices' data. Now, the proper stride is used.
- When importing m2 vertices, the coordinates are converted from Z-up to Y-up. This wasn't done for bones however, so they were still using the wrong coordinate system. I hackily fixed this while importing. I wouldn't be surprised if there were other places that read 3D coordinates without converting them, but I haven't investigated.
- The exported UVs were 1 unit too high. This has been fixed.
- The `GLTFWriter` converts bones' pivot points from absolute coordinates to relative coordinates. To do so, it checks for the presence of a parent bone. However, it accessed the wrong object so the branch never succeeded. Now, the parent is correctly identified.
- I added a glTF node for the model's armature. All root bones are parented to it. I also renamed some other nodes so everything looks nice in Blender.