### PR TITLE
Implement terrain textures from alpha maps option in Blender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed missing map name from raw ADT export filenames.
 - Fixed missing bone data from OBJ exports with bone JSON exports enabled.
 - Improved blending on some character textures.
+- Added option to blend the terrain textures from the exported alpha maps in the Blender add-on.
 
 0.1.59 (29-02-2024)
 - Initial support for exporting textured character models and their customizations to glTF. Some customizations are not yet supported.

--- a/addons/blender/2.80/io_scene_wowobj/__init__.py
+++ b/addons/blender/2.80/io_scene_wowobj/__init__.py
@@ -51,9 +51,9 @@ class Settings:
     importM2 = True
     importGOBJ = True
     importTextures = True
-    useTerrainBlending = False
+    useTerrainBlending = True
 
-    def __init__(self, useAlpha = True, createVertexGroups = False, allowDuplicates = False, importWMO = True, importWMOSets = True, importM2 = True, importGOBJ = True, importTextures = True, useTerrainBlending = False):
+    def __init__(self, useAlpha = True, createVertexGroups = False, allowDuplicates = False, importWMO = True, importWMOSets = True, importM2 = True, importGOBJ = True, importTextures = True, useTerrainBlending = True):
         self.useAlpha = useAlpha
         self.createVertexGroups = createVertexGroups
         self.allowDuplicates = allowDuplicates
@@ -83,7 +83,7 @@ class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
     useAlpha: bpy.props.BoolProperty(name = 'Use Alpha', description = 'Link alpha channel for materials', default = 1)
     createVertexGroups: bpy.props.BoolProperty(name = 'Create Vertex Groups', description = 'Create vertex groups for submeshes', default = 0)
     allowDuplicates: bpy.props.BoolProperty(name = 'Allow Duplicates (ADT)', description = 'Bypass the duplicate M2/WMO protection for ADT tiles', default = 0)
-    useTerrainBlending: bpy.props.BoolProperty(name = 'Use terrain blending', description = 'Blend terrain textures using exported alpha maps', default = 0)
+    useTerrainBlending: bpy.props.BoolProperty(name = 'Use terrain blending', description = 'Blend terrain textures using exported alpha maps', default = 1)
 
     def execute(self, context):
         settings = Settings(

--- a/addons/blender/2.80/io_scene_wowobj/__init__.py
+++ b/addons/blender/2.80/io_scene_wowobj/__init__.py
@@ -51,8 +51,9 @@ class Settings:
     importM2 = True
     importGOBJ = True
     importTextures = True
+    useTerrainBlending = False
 
-    def __init__(self, useAlpha = True, createVertexGroups = False, allowDuplicates = False, importWMO = True, importWMOSets = True, importM2 = True, importGOBJ = True, importTextures = True):
+    def __init__(self, useAlpha = True, createVertexGroups = False, allowDuplicates = False, importWMO = True, importWMOSets = True, importM2 = True, importGOBJ = True, importTextures = True, useTerrainBlending = False):
         self.useAlpha = useAlpha
         self.createVertexGroups = createVertexGroups
         self.allowDuplicates = allowDuplicates
@@ -61,6 +62,7 @@ class Settings:
         self.importM2 = importM2
         self.importGOBJ = importGOBJ
         self.importTextures = importTextures
+        self.useTerrainBlending = useTerrainBlending
 
 class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
     '''Load a Wavefront OBJ File with additional ADT metadata'''
@@ -81,6 +83,7 @@ class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
     useAlpha: bpy.props.BoolProperty(name = 'Use Alpha', description = 'Link alpha channel for materials', default = 1)
     createVertexGroups: bpy.props.BoolProperty(name = 'Create Vertex Groups', description = 'Create vertex groups for submeshes', default = 0)
     allowDuplicates: bpy.props.BoolProperty(name = 'Allow Duplicates (ADT)', description = 'Bypass the duplicate M2/WMO protection for ADT tiles', default = 0)
+    useTerrainBlending: bpy.props.BoolProperty(name = 'Use terrain blending', description = 'Blend terrain textures using exported alpha maps', default = 0)
 
     def execute(self, context):
         settings = Settings(
@@ -91,7 +94,8 @@ class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
             importWMOSets = self.importWMOSets,
             importM2 = self.importM2,
             importGOBJ = self.importGOBJ,
-            importTextures = self.importTextures
+            importTextures = self.importTextures,
+            useTerrainBlending = self.useTerrainBlending,
         )
 
         from . import import_wowobj
@@ -118,6 +122,7 @@ class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
         box.prop(self, 'useAlpha')
         box.prop(self, 'createVertexGroups')
         box.prop(self, 'allowDuplicates')
+        box.prop(self, 'useTerrainBlending')
 
 def menu_func_import(self, context):
     self.layout.operator(ImportWoWOBJ.bl_idname, text='WoW M2/WMO/ADT (.obj)')

--- a/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
+++ b/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
@@ -83,6 +83,8 @@ def createStandardMaterial(materialName, textureLocation, settings):
     # Set the specular value to 0 by default.
     principled.inputs[SPECULAR_INPUT_NAME].default_value = 0
 
+    return material
+
 
 MIX_NODE_COLOR_SOCKETS = {}
 
@@ -183,6 +185,8 @@ def createBlendedTerrain(materialName, textureLocation, layers, baseDir):
         node_tree.links.new(
             last_mix_node.outputs[MIX_NODE_COLOR_SOCKETS['out']['Result']],
             principled.inputs['Base Color'])
+
+    return material
 
             
 def importWoWOBJ(objectFile, givenParent = None, settings = None):

--- a/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
+++ b/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
@@ -138,14 +138,17 @@ def createBlendedTerrain(materialName, textureLocation, layers, baseDir):
         texture_coords = nodes.new('ShaderNodeTexCoord')
 
         texture_mapping = nodes.new('ShaderNodeMapping')
-        texture_mapping.inputs[3].default_value[0] = 6
-        texture_mapping.inputs[3].default_value[1] = 6
+        texture_mapping.inputs[3].default_value[0] = 8
+        texture_mapping.inputs[3].default_value[1] = 8
+        texture_mapping.inputs[3].default_value[2] = 8
 
         node_tree.links.new(texture_coords.outputs['UV'], texture_mapping.inputs['Vector'])
 
         alpha_map = nodes.new('ShaderNodeTexImage')
         alpha_map.image = loadImage(textureLocation)
         alpha_map.image.colorspace_settings.name = 'Non-Color'
+        alpha_map.interpolation = 'Cubic'
+        alpha_map.extension = 'EXTEND'
 
         alpha_map_channels = nodes.new('ShaderNodeSeparateColor')
         node_tree.links.new(alpha_map.outputs['Color'], alpha_map_channels.inputs['Color'])

--- a/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
+++ b/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
@@ -3,7 +3,6 @@ import bmesh
 import os
 import csv
 import hashlib
-import re
 import json
 
 from math import radians


### PR DESCRIPTION
Implement the option to do terrain texture blending directly in Blender when using the "Alpha Maps" terrain texture quality export option.