### PR TITLE
Option to export single wmo types

### DIFF
--- a/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
+++ b/addons/blender/2.80/io_scene_wowobj/import_wowobj.py
@@ -273,7 +273,7 @@ def createBlendedTerrain(materialName, textureLocation, layers, baseDir):
         bpy.data.materials.remove(material)
 
             
-def importWoWOBJ(objectFile, givenParent = None, settings = None):
+def importWoWOBJ(objectFile, givenParent = None, settings = None, doodadSets = None):
     baseDir, fileName = os.path.split(objectFile)
 
     print('Parsing OBJ: ' + fileName)
@@ -544,12 +544,11 @@ def importWoWOBJ(objectFile, givenParent = None, settings = None):
 
                         collection.link(parent)
 
-                        ## Only import OBJ if model is not yet in scene, otherwise copy existing
-                        if os.path.basename(row['ModelFile']) not in bpy.data.objects:
-                            importedFile = importWoWOBJ(os.path.join(baseDir, row['ModelFile']), parent, settings)
+                        if os.path.exists(os.path.join(baseDir, row['ModelFile'].replace('.obj', '_ModelPlacementInformation.csv'))):
+                            # always import when it has doodad sets
+                            importedFile = importWoWOBJ(os.path.join(baseDir, row['ModelFile']), parent, settings, doodadSets=set(row['DoodadSetNames'].split(',')))
                         else:
-                            ## Don't copy WMOs with doodads!
-                            if os.path.exists(os.path.join(baseDir, row['ModelFile'].replace('.obj', '_ModelPlacementInformation.csv'))):
+                            if os.path.basename(row['ModelFile']) not in bpy.data.objects:
                                 importedFile = importWoWOBJ(os.path.join(baseDir, row['ModelFile']), parent, settings)
                             else:
                                 originalObject = bpy.data.objects[os.path.basename(row['ModelFile'])]
@@ -601,6 +600,9 @@ def importWoWOBJ(objectFile, givenParent = None, settings = None):
                     bpy.context.scene['importedModelIDs'] = tempModelIDList
                 elif settings.importWMOSets:
                     # WMO CSV
+                    if doodadSets is not None and row['DoodadSet'] not in doodadSets:
+                        continue
+
                     print('WMO M2 import: ' + row['ModelFile'])
                     if os.path.basename(row['ModelFile']) not in bpy.data.objects:
                         importedFile = importWoWOBJ(os.path.join(baseDir, row['ModelFile']), None, settings)

--- a/src/default_config.jsonc
+++ b/src/default_config.jsonc
@@ -66,6 +66,7 @@
 	"mapsIncludeWMO": true,
 	"mapsIncludeM2": true,
 	"mapsIncludeWMOSets": true,
+	"mapsSingleWMO": false,
 	"mapsIncludeFoliage": true,
 	"mapsIncludeLiquid": false,
 	"mapsIncludeGameObjects": true,

--- a/src/index.html
+++ b/src/index.html
@@ -420,14 +420,6 @@
 								<input type="checkbox" v-model="config.mapsExportRaw"/>
 								<span>Export Raw</span>
 							</label>
-							<label class="ui-checkbox" title="Include WMO objects (large objects such as buildings)">
-								<input type="checkbox" v-model="config.mapsIncludeWMO"/>
-								<span>Export WMO</span>
-							</label>
-							<label class="ui-checkbox" v-if="config.mapsIncludeWMO" title="Include objects inside WMOs (interior decorations)">
-								<input type="checkbox" v-model="config.mapsIncludeWMOSets"/>
-								<span>Export WMO Sets</span>
-							</label>
 							<label class="ui-checkbox" title="Export M2 objects on this tile (smaller objects such as trees)">
 								<input type="checkbox" v-model="config.mapsIncludeM2"/>
 								<span>Export M2</span>
@@ -447,6 +439,19 @@
 							<label v-if="!config.mapsExportRaw" class="ui-checkbox" title="Include terrain holes for WMOs">
 								<input type="checkbox" v-model="config.mapsIncludeHoles"/>
 								<span>Include Holes</span>
+							</label>
+							<span class="header">WMOs</span>
+							<label class="ui-checkbox" title="Include WMO objects (large objects such as buildings)">
+								<input type="checkbox" v-model="config.mapsIncludeWMO"/>
+								<span>Included</span>
+							</label>
+							<label class="ui-checkbox" v-if="config.mapsIncludeWMO" title="Include objects inside WMOs (interior decorations)">
+								<input type="checkbox" v-model="config.mapsIncludeWMOSets"/>
+								<span>Objects</span>
+							</label>
+							<label class="ui-checkbox" v-if="config.mapsIncludeWMO && config.mapsIncludeWMOSets && config.enableSharedChildren" title="Always export all doodad sets. This prevents exporting a copy of the WMO for each used set.">
+								<input type="checkbox" v-model="config.mapsSingleWMO"/>
+								<span>All object sets</span>
 							</label>
 							<span class="header">Model Textures</span>
 							<label class="ui-checkbox" title="Include textures when exporting models">

--- a/src/js/3D/exporters/ADTExporter.js
+++ b/src/js/3D/exporters/ADTExporter.js
@@ -1076,6 +1076,7 @@ class ADTExporter {
 					const usingNames = !!objAdt.wmoNames;
 					for (const model of objAdt.worldModels) {
 						const useADTSets = model & 0x80;
+						const singleWMO = config.mapsSingleWMO && !useADTSets;
 						helper.setCurrentTaskValue(worldModelIndex++);
 
 						let fileDataID;
@@ -1091,12 +1092,16 @@ class ADTExporter {
 							}
 
 							if (!config.mapsExportRaw) {
+								let fileNameSuffix = '_set' + model.doodadSet + '.obj';
+								if (singleWMO) {
+									fileNameSuffix = '.obj';
+								}
 								if (fileName !== undefined) {
 									// Replace WMO extension with OBJ.
-									fileName = ExportHelper.replaceExtension(fileName, '_set' + model.doodadSet + '.obj');
+									fileName = ExportHelper.replaceExtension(fileName, fileNameSuffix);
 								} else {
 									// Handle unknown WMO files.
-									fileName = listfile.formatUnknownFile(fileDataID, '_set' + model.doodadSet + '.obj');
+									fileName = listfile.formatUnknownFile(fileDataID, fileNameSuffix);
 								}
 							}
 
@@ -1107,7 +1112,14 @@ class ADTExporter {
 								modelPath = path.join(dir, path.basename(fileName));
 
 							const doodadSets = useADTSets ? objAdt.doodadSets : [model.doodadSet];
-							const cacheID = fileDataID + '-' + doodadSets.join(',');
+							if (doodadSets.indexOf(0) === -1) {
+								// also add the default set to the list, since it's always exported
+								doodadSets.splice(0, 0, 0);
+							}
+							let cacheID = fileDataID + '-' + doodadSets.join(',');
+							if (singleWMO) {
+								cacheID = fileDataID;
+							}
 
 							if (!objectCache.has(cacheID)) {
 								const data = await casc.getFile(fileDataID);
@@ -1123,9 +1135,15 @@ class ADTExporter {
 										for (const setIndex of objAdt.doodadSets)
 											mask[setIndex] = { checked: true };
 									} else {
-										mask[model.doodadSet] = { checked: true };
+										if (singleWMO) {
+											for (let setIndex = 0; setIndex < wmoLoader.wmo.doodadSets.length; setIndex++) {
+												mask[setIndex] = { checked: true };
+											}
+										} else {
+											mask[model.doodadSet] = { checked: true };
+										}
 									}
-									
+
 									wmoLoader.setDoodadSetMask(mask);
 								}
 


### PR DESCRIPTION
Add option when exporting map tiles to always export all dodad sets for each WMO, thus preventing the creation of several copies of the same WMO for each used doodad set, in effect acting like you exported the WMO from the models tab with all doodad sets checked. Also updated the blender add-on to deal with this case.

I'm opening the PR because I personally need this, but feel free to decline if you don't think it's useful to the community.