### PR TITLE
Fixes of ADT's MH2O bitmap offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 
 # Runtime directory for tests.
 /tests/user_data
+
+.vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added exporting of other WDT files for raw map exports.
 - Added option to blend the terrain textures from the exported alpha maps in the Blender add-on.
 - Improved blending on some character textures.
+- Improved memory usage for WMO previewing and exporting.
 - Fixed missing map name from raw ADT export filenames.
 - Fixed missing bone data from OBJ exports with bone JSON exports enabled.
 - Fixed issue with alpha maps from early maps such as Emerald Dream being exported incorrectly.
@@ -11,6 +12,7 @@
 - Fixed issue with character tab layout being unusable on higher display sizes.
 - Fixed issue that caused character texture overlay to stop appearing after changing tabs.
 - Fixed issue that caused geoset control in the Models and Character tabs to be linked.
+- Fixed issue that caused wow.export to run out of memory when exporting incredibly large WMOs.
 
 0.1.59 (29-02-2024)
 - Initial support for exporting textured character models and their customizations to glTF. Some customizations are not yet supported.

--- a/export-tools.js
+++ b/export-tools.js
@@ -1,0 +1,194 @@
+global.BUILD_RELEASE = false;
+
+const core = require('./src/js/core');
+core.view.$watch = () => { };
+const path = require('path');
+const ExportHelper = require('./src/js/casc/export-helper');
+const RCPServer = require('./src/js/rcp/rcp-server');
+const WMOExporter = require('./src/js/3D/exporters/WMOExporter');
+const ADTExporter = require('./src/js/3D/exporters/ADTExporter');
+const Config = require("./src/js/config")
+const WDCReader = require('./src/js/db/WDCReader');
+const CASCRemote = require('./src/js/casc/casc-source-remote');
+const util = require('util');
+const WDTLoader = require('./src/js/3D/loaders/WDTLoader');
+const listfile = require('./src/js/casc/listfile');
+const constants = require('./src/js/constants');
+
+const TILE_SIZE = constants.GAME.TILE_SIZE;
+const MAP_OFFSET = constants.GAME.MAP_OFFSET;
+
+core.createProgress = (segments) => {
+    return {
+        segWeight: 1 / segments,
+        value: 0,
+        step: async function (text) {
+            this.value++;
+        }
+    }
+};
+
+const parseMapEntry = (entry) => {
+    const match = entry.match(/\[(\d+)\]\31([^\31]+)\31\(([^)]+)\)/);
+    if (!match)
+        throw new Error('Unexpected map entry');
+
+    return { id: parseInt(match[1]), name: match[2], dir: match[3] };
+};
+
+const loadMap = async (mapID, mapDir) => {
+    const mapDirLower = mapDir.toLowerCase();
+
+    selectedMapID = mapID;
+    selectedMapDir = mapDirLower;
+
+    selectedWDT = null;
+    core.view.mapViewerHasWorldModel = false;
+
+    // Attempt to load the WDT for this map for chunk masking.
+    const wdtPath = util.format('world/maps/%s/%s.wdt', mapDirLower, mapDirLower);
+
+
+    try {
+        const data = await core.view.casc.getFileByName(wdtPath);
+        const wdt = selectedWDT = new WDTLoader(data);
+        wdt.load();
+
+        // Enable the 'Export Global WMO' button if available.
+        if (wdt.worldModelPlacement)
+            core.view.mapViewerHasWorldModel = true;
+
+        core.view.mapViewerChunkMask = wdt.tiles;
+    } catch (e) {
+        // Unable to load WDT, default to all chunks enabled.
+        core.view.mapViewerChunkMask = null;
+    }
+
+    // Reset the tile selection.
+    core.view.mapViewerSelection.splice(0);
+
+    // While not used directly by the components, we update this reactive value
+    // so that the components know a new map has been selected, and to request tiles.
+    core.view.mapViewerSelectedMap = mapID;
+
+    // Purposely provide the raw mapDir here as it's used by the external link module
+    // and wow.tools requires a properly cased map name.
+    core.view.mapViewerSelectedDir = mapDir;
+
+    return core.view.mapViewerChunkMask;
+};
+
+gameObjectsDB2 = null;
+
+const collectGameObjects = async (mapID, filter) => {
+    // Load GameObjects.db2/GameObjectDisplayInfo.db2 on-demand.
+    if (gameObjectsDB2 === null) {
+        const objTable = new WDCReader('DBFilesClient/GameObjects.db2');
+        await objTable.parse();
+
+        const idTable = new WDCReader('DBFilesClient/GameObjectDisplayInfo.db2');
+        await idTable.parse();
+
+        // Index all of the rows by the map ID.
+        gameObjectsDB2 = new Map();
+        for (const row of objTable.getAllRows().values()) {
+            // Look-up the fileDataID ahead of time.
+            const fidRow = idTable.getRow(row.DisplayID);
+            if (fidRow !== null) {
+                row.FileDataID = fidRow.FileDataID;
+
+                let map = gameObjectsDB2.get(row.OwnerID);
+                if (map === undefined) {
+                    map = new Set();
+                    map.add(row);
+                    gameObjectsDB2.set(row.OwnerID, map);
+                } else {
+                    map.add(row);
+                }
+            }
+        }
+    }
+
+    const result = new Set();
+    const mapObjects = gameObjectsDB2.get(mapID);
+
+    if (mapObjects !== undefined) {
+        for (const obj of mapObjects) {
+            if (filter !== undefined && filter(obj))
+                result.add(obj);
+        }
+    }
+
+    return result;
+};
+
+const exportMap = async (map) => {
+    const tiles = await loadMap(map.id, map.dir);
+
+    console.log(`export map ${map.dir} ${map.id}`);
+
+    if (tiles) {
+        
+        const wowTests = 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
+        const exportPath = path.join(wowTests, 'maps', map.dir.toLowerCase());
+
+        const exportTiles = tiles.map((t, i) => { return { t, i } }).filter(t => t.t == 1).map(t => t.i);
+        const helper = new ExportHelper(exportTiles.length, 'tile');
+        helper.start();
+
+        for (var i = 0; i < exportTiles.length; i++) {
+            var adt = new ADTExporter(map.id, map.dir, exportTiles[i]);
+
+            const startX = MAP_OFFSET - (adt.tileX * TILE_SIZE) - TILE_SIZE;
+            const startY = MAP_OFFSET - (adt.tileY * TILE_SIZE) - TILE_SIZE;
+            const endX = startX + TILE_SIZE;
+            const endY = startY + TILE_SIZE;
+
+            gameObjects = await collectGameObjects(selectedMapID, obj => {
+                const [posX, posY] = obj.Pos;
+                return posX > startX && posX < endX && posY > startY && posY < endY;
+            });
+
+            await adt.export(wowTests, 0, null, helper);
+        }
+    }
+}
+
+(async () => {
+
+    core.rcp = new RCPServer();
+    core.rcp.load();
+
+    const casc = new CASCRemote('eu');
+    await casc.init();
+    casc.locale = core.view.availableLocale.flags.enUS;
+    var products = casc.getProductList();
+    Config.load();
+    Config.resetAllToDefault();
+
+
+    var buildIndex = 0;
+    await casc.load(buildIndex);
+
+    //Читаем файлы карт
+    const table = new WDCReader('DBFilesClient/Map.db2');
+    await table.parse();
+
+    const maps = [];
+    for (const [id, entry] of table.getAllRows()) {
+        const wdtPath = util.format('world/maps/%s/%s.wdt', entry.Directory, entry.Directory);
+        if (listfile.getByFilename(wdtPath))
+            maps.push(util.format('%d\x19[%d]\x19%s\x19(%s)', entry.ExpansionID, id, entry.MapName_lang, entry.Directory));
+    }
+
+    core.view.mapViewerMaps = maps;
+
+
+    var mapEntries = maps.map(parseMapEntry);
+
+    await exportMap(mapEntries[0]);
+
+
+})();
+
+

--- a/export-tools.js
+++ b/export-tools.js
@@ -136,7 +136,11 @@ const collectGameObjects = async (mapID) => {
     }
 
     const mapObjects = gameObjectsDB2.get(mapID);
-    return [...mapObjects];
+    if(mapObjects)
+    {
+        return [...mapObjects];
+    }
+    return [];
 };
 
 const exportMap = async (map, exportDirectory, region, product, version) => {
@@ -288,7 +292,7 @@ const main = async (attempts) => {
     const region = argv[1] || 'eu';
     const product = argv[2] || 'wow';
     const version = argv[3] || '11.2.0.62493';
-    const mapId = argv[4] || 0;
+    const mapId = argv[4] || 30;
     const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wow\\source\\eu_wow_11_2_0_62493';
 
     if (comm == 'versions') {

--- a/export-tools.js
+++ b/export-tools.js
@@ -178,8 +178,6 @@ const exportMap = async (map, exportDirectory, region, product, version) => {
 
     if (tiles) {
 
-
-
         const exportTiles = tiles.map((t, i) => { return { t, i } }).filter(t => t.t == 1).map(t => t.i);
         const helper = new ExportHelper(exportTiles.length, 'tile');
         helper.start();

--- a/export-tools.js
+++ b/export-tools.js
@@ -187,7 +187,7 @@ const exportMap = async (map, exportDirectory, region, product, version) => {
 
             await adt.export(exportPath, 0, gameObjects, helper);
 
-            write_console(JSON.stringify({all: exportTiles.length, current: i + 1}));
+            write_console(JSON.stringify({ all: exportTiles.length, current: i + 1 }));
         }
     }
 }
@@ -266,27 +266,44 @@ const downloadMaps = async (region, product, version, mapId, exportPath) => {
     await exportMap(mapEntries.find(x => x.id == mapId), exportPath, region, product, version);
 };
 
+const main = async (attempts) => {
+
+    attempts = attempts || 0;
+
+    try {
+
+        var argv = process.argv.slice(2);
+
+        const comm = argv[0] || 'download'
+        const region = argv[1] || 'eu';
+        const product = argv[2] || 'wowt';
+        const version = argv[3] || '11.1.7.61967';
+        const mapId = argv[4] || 0;
+        const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
+
+        if (comm == 'versions') {
+            await sendAvailableVersions(region);
+        }
+        else if (comm == 'maps') {
+            await sendAvailableMaps(region, product, version);
+        }
+        else if (comm == 'download') {
+            await downloadMaps(region, product, version, mapId, exportPath);
+        }
+    }
+    catch (ex) {
+        if (attempts < 3) {
+            await main(attempts + 1);
+        }
+        else {
+            throw ex;
+        }
+    }
+}
+
 (async () => {
-
-    var argv = process.argv.slice(2);
-
-    const comm = argv[0] || 'download'
-    const region = argv[1] || 'eu';
-    const product = argv[2] || 'wowt';
-    const version = argv[3] || '11.1.7.61967';
-    const mapId = argv[4] || 0;
-    const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
-
-    if (comm == 'versions') {
-        sendAvailableVersions(region);
-    }
-    else if (comm == 'maps') {
-        sendAvailableMaps(region, product, version);
-    }
-    else if (comm == 'download') {
-        await downloadMaps(region, product, version, mapId, exportPath);
-    }
-
+    await main(0);
 })();
+
 
 

--- a/export-tools.js
+++ b/export-tools.js
@@ -161,6 +161,9 @@ const exportMap = async (map, exportDirectory, region, product, version) => {
     config.mapsIncludeFoliage = false;
     config.modelsExportCollision = true;
     config.exportDirectory = exportDirectory;
+    config.exportWMOMeta = true;
+    config.modelsExportWMOGroups = true;
+    config.exportFoliageMeta = false;
 
     if (tiles) {
         const exportTiles = tiles.map((t, i) => { return { t, i } }).filter(t => t.t == 1).map(t => t.i);
@@ -283,10 +286,10 @@ const main = async (attempts) => {
 
     const comm = argv[0] || 'download'
     const region = argv[1] || 'eu';
-    const product = argv[2] || 'wowt';
-    const version = argv[3] || '11.1.7.61967';
+    const product = argv[2] || 'wow';
+    const version = argv[3] || '11.2.0.62493';
     const mapId = argv[4] || 0;
-    const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
+    const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wow\\source\\eu_wow_11_2_0_62493';
 
     if (comm == 'versions') {
         await sendAvailableVersions(region);

--- a/export-tools.js
+++ b/export-tools.js
@@ -31,9 +31,7 @@ function folderExistsSync(path) {
     }
 }
 
-if (!folderExistsSync('./tests/user_data')) {
-    fs.mkdir('./tests/user_data');
-}
+fs.mkdirSync('./tests/user_data', { recursive: true });
 
 const TILE_SIZE = constants.GAME.TILE_SIZE;
 const MAP_OFFSET = constants.GAME.MAP_OFFSET;
@@ -188,6 +186,8 @@ const exportMap = async (map, exportDirectory, region, product, version) => {
             });
 
             await adt.export(exportPath, 0, gameObjects, helper);
+
+            write_console(JSON.stringify({all: exportTiles.length, current: i + 1}));
         }
     }
 }
@@ -274,7 +274,7 @@ const downloadMaps = async (region, product, version, mapId, exportPath) => {
     const region = argv[1] || 'eu';
     const product = argv[2] || 'wowt';
     const version = argv[3] || '11.1.7.61967';
-    const mapId = argv[4] || 1;
+    const mapId = argv[4] || 0;
     const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
 
     if (comm == 'versions') {

--- a/export-tools.js
+++ b/export-tools.js
@@ -127,11 +127,24 @@ const exportMap = async (map) => {
 
     console.log(`export map ${map.dir} ${map.id}`);
 
-    core.view.config.
+    const config = core.view.config;
+    config.mapsExportRaw = false;
+    config.pathFormat = "posix";
+    config.mapsIncludeHoles = true;
+    config.overwriteFiles = true;
+    config.mapsIncludeWMO = true;
+    config.mapsIncludeM2 = true;
+    config.mapsIncludeGameObjects = true;
+    config.enableSharedChildren = true;
+    config.removePathSpaces = true;
+    config.mapsIncludeWMOSets = true; //??
+    config.mapsIncludeLiquid = true;
+    config.mapsIncludeFoliage = false;
+	config.exportDirectory = 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
+
 
     if (tiles) {
-        
-        const wowTests = 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
+
         const exportPath = path.join(wowTests, 'maps', map.dir.toLowerCase());
 
         const exportTiles = tiles.map((t, i) => { return { t, i } }).filter(t => t.t == 1).map(t => t.i);

--- a/export-tools.js
+++ b/export-tools.js
@@ -228,7 +228,7 @@ const sendAvailableMaps = async (region, product, version) => {
 
     var mapEntries = maps.map(parseMapEntry);
 
-    write_console(JSON.stringify(mapEntries.map(x => { return { id: x.id, name: x.name } })));
+    write_console(JSON.stringify(mapEntries.map(x => { return { id: x.id, name: x.name, dir: x.dir } })));
 }
 
 const downloadMaps = async (region, product, version, mapId, exportPath) => {

--- a/export-tools.js
+++ b/export-tools.js
@@ -267,42 +267,28 @@ const downloadMaps = async (region, product, version, mapId, exportPath) => {
 };
 
 const main = async (attempts) => {
+    var argv = process.argv.slice(2);
 
-    attempts = attempts || 0;
+    const comm = argv[0] || 'maps'
+    const region = argv[1] || 'eu';
+    const product = argv[2] || 'wowt';
+    const version = argv[3] || '11.1.7.61967';
+    const mapId = argv[4] || 0;
+    const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
 
-    try {
-
-        var argv = process.argv.slice(2);
-
-        const comm = argv[0] || 'download'
-        const region = argv[1] || 'eu';
-        const product = argv[2] || 'wowt';
-        const version = argv[3] || '11.1.7.61967';
-        const mapId = argv[4] || 0;
-        const exportPath = argv[5] || 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
-
-        if (comm == 'versions') {
-            await sendAvailableVersions(region);
-        }
-        else if (comm == 'maps') {
-            await sendAvailableMaps(region, product, version);
-        }
-        else if (comm == 'download') {
-            await downloadMaps(region, product, version, mapId, exportPath);
-        }
+    if (comm == 'versions') {
+        await sendAvailableVersions(region);
     }
-    catch (ex) {
-        if (attempts < 3) {
-            await main(attempts + 1);
-        }
-        else {
-            throw ex;
-        }
+    else if (comm == 'maps') {
+        await sendAvailableMaps(region, product, version);
+    }
+    else if (comm == 'download') {
+        await downloadMaps(region, product, version, mapId, exportPath);
     }
 }
 
 (async () => {
-    await main(0);
+    await main();
 })();
 
 

--- a/export-tools.js
+++ b/export-tools.js
@@ -127,6 +127,8 @@ const exportMap = async (map) => {
 
     console.log(`export map ${map.dir} ${map.id}`);
 
+    core.view.config.
+
     if (tiles) {
         
         const wowTests = 'C:\\Users\\Hrust\\OneDrive\\Рабочий стол\\wowTests';
@@ -144,12 +146,12 @@ const exportMap = async (map) => {
             const endX = startX + TILE_SIZE;
             const endY = startY + TILE_SIZE;
 
-            gameObjects = await collectGameObjects(selectedMapID, obj => {
+            const gameObjects = await collectGameObjects(selectedMapID, obj => {
                 const [posX, posY] = obj.Pos;
                 return posX > startX && posX < endX && posY > startY && posY < endY;
             });
 
-            await adt.export(wowTests, 0, null, helper);
+            await adt.export(exportPath, 0, gameObjects, helper);
         }
     }
 }

--- a/export-tools.js
+++ b/export-tools.js
@@ -281,7 +281,7 @@ const downloadMaps = async (region, product, version, mapId, exportPath) => {
 const main = async (attempts) => {
     var argv = process.argv.slice(2);
 
-    const comm = argv[0] || 'maps'
+    const comm = argv[0] || 'versions'
     const region = argv[1] || 'eu';
     const product = argv[2] || 'wowt';
     const version = argv[3] || '11.1.7.61967';

--- a/src/js/3D/loaders/ADTLoader.js
+++ b/src/js/3D/loaders/ADTLoader.js
@@ -3,515 +3,515 @@
 	Authors: Kruithne <kruithne@gmail.com>
 	License: MIT
  */
-	const LoaderGenerics = require('./LoaderGenerics');
+const LoaderGenerics = require('./LoaderGenerics');
 
-	class ADTLoader {
-		/**
-		 * Construct a new ADTLoader instance.
-		 * @param {BufferWrapper} data 
-		 */
-		constructor(data) {
-			this.data = data;
-		}
+class ADTLoader {
+	/**
+	 * Construct a new ADTLoader instance.
+	 * @param {BufferWrapper} data 
+	 */
+	constructor(data) {
+		this.data = data;
+	}
+
+	/**
+	 * Parse this ADT as a root file.
+	 */
+	loadRoot() {
+		this.chunks = new Array(16 * 16);
+		this.chunkIndex = 0;
+
+		this.handlers = ADTChunkHandlers;
+		this._load();
+	}
+
+	/**
+	 * Parse this ADT as an object file.
+	 */
+	loadObj() {
+		this.handlers = ADTObjChunkHandlers;
+		this._load();
+	}
+
+	/**
+	 * Parse this ADT as a texture file.
+	 * @param {WDTLoader} wdt
+	 */
+	loadTex(wdt) {
+		this.texChunks = new Array(16 * 16);
+		this.chunkIndex = 0;
+		this.wdt = wdt;
+
+		this.handlers = ADTTexChunkHandlers;
+		this._load();
+	}
+
+	/**
+	 * Load the ADT file, parsing it.
+	 */
+	_load() {
+		while (this.data.remainingBytes > 0) {
+			const chunkID = this.data.readUInt32LE();
+			const chunkSize = this.data.readUInt32LE();
+			const nextChunkPos = this.data.offset + chunkSize;
+
+			const handler = this.handlers[chunkID];
+			if (handler)
+				handler.call(this, this.data, chunkSize);
 	
-		/**
-		 * Parse this ADT as a root file.
-		 */
-		loadRoot() {
-			this.chunks = new Array(16 * 16);
-			this.chunkIndex = 0;
-	
-			this.handlers = ADTChunkHandlers;
-			this._load();
-		}
-	
-		/**
-		 * Parse this ADT as an object file.
-		 */
-		loadObj() {
-			this.handlers = ADTObjChunkHandlers;
-			this._load();
-		}
-	
-		/**
-		 * Parse this ADT as a texture file.
-		 * @param {WDTLoader} wdt
-		 */
-		loadTex(wdt) {
-			this.texChunks = new Array(16 * 16);
-			this.chunkIndex = 0;
-			this.wdt = wdt;
-	
-			this.handlers = ADTTexChunkHandlers;
-			this._load();
-		}
-	
-		/**
-		 * Load the ADT file, parsing it.
-		 */
-		_load() {
-			while (this.data.remainingBytes > 0) {
-				const chunkID = this.data.readUInt32LE();
-				const chunkSize = this.data.readUInt32LE();
-				const nextChunkPos = this.data.offset + chunkSize;
-	
-				const handler = this.handlers[chunkID];
-				if (handler)
-					handler.call(this, this.data, chunkSize);
-		
-				// Ensure that we start at the next chunk exactly.
-				this.data.seek(nextChunkPos);
-			}
+			// Ensure that we start at the next chunk exactly.
+			this.data.seek(nextChunkPos);
 		}
 	}
+}
+
+const ADTChunkHandlers = {
+	// MVER (Version)
+	0x4D564552: function(data) {
+		this.version = data.readUInt32LE();
+		if (this.version !== 18)
+			throw new Error('Unexpected ADT version: ' + this.version);
+	},
+
+	// MCNK
+	0x4D434E4B: function(data, chunkSize) {
+		const endOfs = data.offset + chunkSize;
+		const chunk = this.chunks[this.chunkIndex++] = {
+			flags: data.readUInt32LE(),
+			indexX: data.readUInt32LE(),
+			indexY: data.readUInt32LE(),
+			nLayers: data.readUInt32LE(),
+			nDoodadRefs: data.readUInt32LE(),
+			holesHighRes: data.readUInt8(8),
+			ofsMCLY: data.readUInt32LE(),
+			ofsMCRF: data.readUInt32LE(),
+			ofsMCAL: data.readUInt32LE(),
+			sizeAlpha: data.readUInt32LE(),
+			ofsMCSH: data.readUInt32LE(),
+			sizeShadows: data.readUInt32LE(),
+			areaID: data.readUInt32LE(),
+			nMapObjRefs: data.readUInt32LE(),
+			holesLowRes: data.readUInt16LE(),
+			unk1: data.readUInt16LE(),
+			lowQualityTextureMap: data.readInt16LE(8),
+			noEffectDoodad: data.readInt64LE(),
+			ofsMCSE: data.readUInt32LE(),
+			numMCSE: data.readUInt32LE(),
+			ofsMCLQ: data.readUInt32LE(),
+			sizeMCLQ: data.readUInt32LE(),
+			position: data.readFloatLE(3),
+			ofsMCCV: data.readUInt32LE(),
+			ofsMCLW: data.readUInt32LE(),
+			unk2: data.readUInt32LE()
+		};
+
+		// Read sub-chunks.
+		while (data.offset < endOfs) {
+			const chunkID = data.readUInt32LE();
+			const subChunkSize = data.readUInt32LE();
+			const nextChunkPos = data.offset + subChunkSize;
+
+			const handler = RootMCNKChunkHandlers[chunkID];
+			if (handler)
+				handler.call(chunk, data, subChunkSize);
 	
-	const ADTChunkHandlers = {
-		// MVER (Version)
-		0x4D564552: function(data) {
-			this.version = data.readUInt32LE();
-			if (this.version !== 18)
-				throw new Error('Unexpected ADT version: ' + this.version);
-		},
-	
-		// MCNK
-		0x4D434E4B: function(data, chunkSize) {
-			const endOfs = data.offset + chunkSize;
-			const chunk = this.chunks[this.chunkIndex++] = {
-				flags: data.readUInt32LE(),
-				indexX: data.readUInt32LE(),
-				indexY: data.readUInt32LE(),
-				nLayers: data.readUInt32LE(),
-				nDoodadRefs: data.readUInt32LE(),
-				holesHighRes: data.readUInt8(8),
-				ofsMCLY: data.readUInt32LE(),
-				ofsMCRF: data.readUInt32LE(),
-				ofsMCAL: data.readUInt32LE(),
-				sizeAlpha: data.readUInt32LE(),
-				ofsMCSH: data.readUInt32LE(),
-				sizeShadows: data.readUInt32LE(),
-				areaID: data.readUInt32LE(),
-				nMapObjRefs: data.readUInt32LE(),
-				holesLowRes: data.readUInt16LE(),
-				unk1: data.readUInt16LE(),
-				lowQualityTextureMap: data.readInt16LE(8),
-				noEffectDoodad: data.readInt64LE(),
-				ofsMCSE: data.readUInt32LE(),
-				numMCSE: data.readUInt32LE(),
-				ofsMCLQ: data.readUInt32LE(),
-				sizeMCLQ: data.readUInt32LE(),
-				position: data.readFloatLE(3),
-				ofsMCCV: data.readUInt32LE(),
-				ofsMCLW: data.readUInt32LE(),
-				unk2: data.readUInt32LE()
+			// Ensure that we start at the next chunk exactly.
+			data.seek(nextChunkPos);
+		}
+	},
+
+	// MH2O (Liquids)
+	0x4D48324F: function(data) {
+		const base = data.offset;
+		let dataOffsets = new Set();
+
+		// SMLiquidChunk
+		const chunks = this.liquidChunks = new Array(256);
+		for (let i = 0; i < 256; i++) {
+			const offsetInstances = data.readUInt32LE();
+			const layerCount = data.readUInt32LE();
+			const offsetAttributes = data.readUInt32LE();
+
+			if (offsetAttributes > 0)
+				dataOffsets.add(offsetAttributes);
+
+			const entryOfs = data.offset;
+			const chunk = chunks[i] = {
+				attributes: { fishable: 0, deep: 0 },
+				instances: new Array(layerCount)
 			};
-	
-			// Read sub-chunks.
-			while (data.offset < endOfs) {
-				const chunkID = data.readUInt32LE();
-				const subChunkSize = data.readUInt32LE();
-				const nextChunkPos = data.offset + subChunkSize;
-	
-				const handler = RootMCNKChunkHandlers[chunkID];
-				if (handler)
-					handler.call(chunk, data, subChunkSize);
-		
-				// Ensure that we start at the next chunk exactly.
-				data.seek(nextChunkPos);
-			}
-		},
-	
-		// MH2O (Liquids)
-		0x4D48324F: function(data) {
-			const base = data.offset;
-			let dataOffsets = new Set();
-	
-			// SMLiquidChunk
-			const chunks = this.liquidChunks = new Array(256);
-			for (let i = 0; i < 256; i++) {
-				const offsetInstances = data.readUInt32LE();
-				const layerCount = data.readUInt32LE();
-				const offsetAttributes = data.readUInt32LE();
-	
-				if (offsetAttributes > 0)
-					dataOffsets.add(offsetAttributes);
-	
-				const entryOfs = data.offset;
-				const chunk = chunks[i] = {
-					attributes: { fishable: 0, deep: 0 },
-					instances: new Array(layerCount)
-				};
-	
-				if (layerCount > 0) {
-					// Read chunk attributes.
-					data.seek(base + offsetAttributes);
-					chunk.attributes.fishable = data.readUInt64LE();
-					chunk.attributes.deep = data.readUInt64LE();
-	
-					// Read SMLiquidInstance array.
-					data.seek(base + offsetInstances);
-					for (let j = 0; j < layerCount; j++) {
-						const instance = chunk.instances[j] = {
-							liquidType: data.readUInt16LE(),
-							liquidObject: data.readUInt16LE(),
-							minHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
-							maxHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
-							xOffset: data.readUInt8(), // 0 if liquidObject <= 41
-							yOffset: data.readUInt8(), // 0 if liquidObject <= 41
-							width: data.readUInt8(), // 8 if liquidObject <= 41
-							height: data.readUInt8(), // 8 if liquidObject <= 41
-							bitmap: [], // Empty == All exist.
-							vertexData: {},
-							offsetExistsBitmap: data.readUInt32LE(),
-							offsetVertexData: data.readUInt32LE()
-						};
-	
-						if (instance.offsetExistsBitmap > 0)
-							dataOffsets.add(instance.offsetExistsBitmap);
-	
-						if (instance.offsetVertexData > 0)
-							dataOffsets.add(instance.offsetVertexData);
-	
-						const instanceOfs = data.offset;
-	
-						if (instance.offsetExistsBitmap > 0)
-						{
-							data.seek(base + instance.offsetExistsBitmap);
-							const bitmapDataLength = Math.floor((instance.width * instance.height + 7) / 8);
-							instance.bitmap = data.readUInt8(bitmapDataLength);
-						}
-						
-						data.seek(instanceOfs);
+
+			if (layerCount > 0) {
+				// Read chunk attributes.
+				data.seek(base + offsetAttributes);
+				chunk.attributes.fishable = data.readUInt64LE();
+				chunk.attributes.deep = data.readUInt64LE();
+
+				// Read SMLiquidInstance array.
+				data.seek(base + offsetInstances);
+				for (let j = 0; j < layerCount; j++) {
+					const instance = chunk.instances[j] = {
+						liquidType: data.readUInt16LE(),
+						liquidObject: data.readUInt16LE(),
+						minHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
+						maxHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
+						xOffset: data.readUInt8(), // 0 if liquidObject <= 41
+						yOffset: data.readUInt8(), // 0 if liquidObject <= 41
+						width: data.readUInt8(), // 8 if liquidObject <= 41
+						height: data.readUInt8(), // 8 if liquidObject <= 41
+						bitmap: [], // Empty == All exist.
+						vertexData: {},
+						offsetExistsBitmap: data.readUInt32LE(),
+						offsetVertexData: data.readUInt32LE()
+					};
+
+					if (instance.offsetExistsBitmap > 0)
+						dataOffsets.add(instance.offsetExistsBitmap);
+
+					if (instance.offsetVertexData > 0)
+						dataOffsets.add(instance.offsetVertexData);
+
+					const instanceOfs = data.offset;
+
+					if (instance.offsetExistsBitmap > 0)
+					{
+						data.seek(base + instance.offsetExistsBitmap);
+						const bitmapDataLength = Math.floor((instance.width * instance.height + 7) / 8);
+						instance.bitmap = data.readUInt8(bitmapDataLength);
 					}
+
+					data.seek(instanceOfs);
 				}
-	
-				data.seek(entryOfs);
 			}
-	
-			dataOffsets = Array.from(dataOffsets).sort((a, b) => a - b);
-	
-			// Retroactively parse vertex data by assuming the structures based on offsets.
-			for (const chunk of chunks) {
-				for (const instance of chunk.instances) {
-					if (instance.offsetVertexData > 0) {
-						const vertexCount = (instance.width + 1) * (instance.height + 1);
-						const ofsIndex = dataOffsets.indexOf(instance.offsetVertexData);
-						const dataSize = dataOffsets[ofsIndex + 1] - instance.offsetVertexData;
-	
-						data.seek(base + instance.offsetVertexData);
-	
-						const mtp = dataSize / vertexCount;
-						const vertexData = instance.vertexData = {};
-	
-						// MTP
-						// 5 = Height, Depth
-						// 8 = Height, UV
-						// 1 = Depth
-						// 9 = Height, UV, Depth
-	
-						// Height
-						if (mtp === 5 || mtp === 8 || mtp === 9)
-							vertexData.height = data.readFloatLE(vertexCount);
-	
-						// Texture Coordinates (UV)
-						if (mtp === 8 || mtp === 9) {
-							const uv = vertexData.uv = new Array(vertexCount);
-							for (let i = 0; i < vertexCount; i++) {
-								uv[i] = {
-									x: data.readUInt16LE(),
-									y: data.readUInt16LE()
-								}
+
+			data.seek(entryOfs);
+		}
+
+		dataOffsets = Array.from(dataOffsets).sort((a, b) => a - b);
+
+		// Retroactively parse vertex data by assuming the structures based on offsets.
+		for (const chunk of chunks) {
+			for (const instance of chunk.instances) {
+				if (instance.offsetVertexData > 0) {
+					const vertexCount = (instance.width + 1) * (instance.height + 1);
+					const ofsIndex = dataOffsets.indexOf(instance.offsetVertexData);
+					const dataSize = dataOffsets[ofsIndex + 1] - instance.offsetVertexData;
+
+					data.seek(base + instance.offsetVertexData);
+
+					const mtp = dataSize / vertexCount;
+					const vertexData = instance.vertexData = {};
+
+					// MTP
+					// 5 = Height, Depth
+					// 8 = Height, UV
+					// 1 = Depth
+					// 9 = Height, UV, Depth
+
+					// Height
+					if (mtp === 5 || mtp === 8 || mtp === 9)
+						vertexData.height = data.readFloatLE(vertexCount);
+
+					// Texture Coordinates (UV)
+					if (mtp === 8 || mtp === 9) {
+						const uv = vertexData.uv = new Array(vertexCount);
+						for (let i = 0; i < vertexCount; i++) {
+							uv[i] = {
+								x: data.readUInt16LE(),
+								y: data.readUInt16LE()
 							}
 						}
-	
-						// Depth
-						if (mtp === 5 || mtp === 1 || mtp === 9)
-							vertexData.depth = data.readUInt8(vertexCount);
 					}
+
+					// Depth
+					if (mtp === 5 || mtp === 1 || mtp === 9)
+						vertexData.depth = data.readUInt8(vertexCount);
 				}
 			}
-		},
-	
-		// MHDR (Header)
-		0x4D484452: function(data) {
-			this.header = {
-				flags: data.readUInt32LE(),
-				ofsMCIN: data.readUInt32LE(),
-				ofsMTEX: data.readUInt32LE(),
-				ofsMMDX: data.readUInt32LE(),
-				ofsMMID: data.readUInt32LE(),
-				ofsMWMO: data.readUInt32LE(),
-				ofsMWID: data.readUInt32LE(),
-				ofsMDDF: data.readUInt32LE(),
-				ofsMODF: data.readUInt32LE(),
-				ofsMFBO: data.readUInt32LE(),
-				ofsMH20: data.readUInt32LE(),
-				ofsMTXF: data.readUInt32LE(),
-				unk: data.readUInt32LE(4)
+		}
+	},
+
+	// MHDR (Header)
+	0x4D484452: function(data) {
+		this.header = {
+			flags: data.readUInt32LE(),
+			ofsMCIN: data.readUInt32LE(),
+			ofsMTEX: data.readUInt32LE(),
+			ofsMMDX: data.readUInt32LE(),
+			ofsMMID: data.readUInt32LE(),
+			ofsMWMO: data.readUInt32LE(),
+			ofsMWID: data.readUInt32LE(),
+			ofsMDDF: data.readUInt32LE(),
+			ofsMODF: data.readUInt32LE(),
+			ofsMFBO: data.readUInt32LE(),
+			ofsMH20: data.readUInt32LE(),
+			ofsMTXF: data.readUInt32LE(),
+			unk: data.readUInt32LE(4)
+		};
+	}
+};
+
+const RootMCNKChunkHandlers = {
+	// MCVT (vertices)
+	0x4D435654: function(data) {
+		this.vertices = data.readFloatLE(145);
+	},
+
+	// MCCV (Vertex Shading)
+	0x4D434356: function(data) {
+		const shading = this.vertexShading = new Array(145);
+		for (let i = 0; i < 145; i++) {
+			shading[i] = {
+				r: data.readUInt8(),
+				g: data.readUInt8(),
+				b: data.readUInt8(),
+				a: data.readUInt8()
+			}
+		}
+	},
+
+	// MCNR (Normals)
+	0x4D434E52: function(data) {
+		const normals = this.normals = new Array(145);
+		for (let i = 0; i < 145; i++) {
+			const x = data.readInt8();
+			const z = data.readInt8();
+			const y = data.readInt8();
+
+			normals[i] = [x, y, z];
+		}
+	},
+
+	// MCBB (Blend Batches)
+	0x4D434242: function(data, chunkSize) {
+		const count = chunkSize / 20;
+		const blend = this.blendBatches = new Array(count);
+
+		for (let i = 0; i < count; i++) {
+			blend[i] = {
+				mbmhIndex: data.readUInt32LE(),
+				indexCount: data.readUInt32LE(),
+				indexFirst: data.readUInt32LE(),
+				vertexCount: data.readUInt32LE(),
+				vertexFirst: data.readUInt32LE()
 			};
 		}
-	};
+	}
+};
+
+const ADTTexChunkHandlers = {
+	// MVER (Version)
+	0x4D564552: function(data) {
+		this.version = data.readUInt32LE();
+		if (this.version !== 18)
+			throw new Error('Unexpected ADT version: ' + this.version);
+	},
+
+	// MTEX (Textures)
+	0x4D544558: function(data, chunkSize) {
+		this.textures = LoaderGenerics.ReadStringBlock(data, chunkSize);
+	},
+
+	// MCNK (Texture Chunks)
+	0x4D434E4B: function(data, chunkSize) {
+		const endOfs = data.offset + chunkSize;
+		const chunk = this.texChunks[this.chunkIndex++] = {};
+
+		// Read sub-chunks.
+		while (data.offset < endOfs) {
+			const chunkID = data.readUInt32LE();
+			const subChunkSize = data.readUInt32LE();
+			const nextChunkPos = data.offset + subChunkSize;
+
+			const handler = TexMCNKChunkHandlers[chunkID];
+			if (handler)
+				handler.call(chunk, data, subChunkSize, this.wdt);
 	
-	const RootMCNKChunkHandlers = {
-		// MCVT (vertices)
-		0x4D435654: function(data) {
-			this.vertices = data.readFloatLE(145);
-		},
-	
-		// MCCV (Vertex Shading)
-		0x4D434356: function(data) {
-			const shading = this.vertexShading = new Array(145);
-			for (let i = 0; i < 145; i++) {
-				shading[i] = {
-					r: data.readUInt8(),
-					g: data.readUInt8(),
-					b: data.readUInt8(),
-					a: data.readUInt8()
-				}
-			}
-		},
-	
-		// MCNR (Normals)
-		0x4D434E52: function(data) {
-			const normals = this.normals = new Array(145);
-			for (let i = 0; i < 145; i++) {
-				const x = data.readInt8();
-				const z = data.readInt8();
-				const y = data.readInt8();
-	
-				normals[i] = [x, y, z];
-			}
-		},
-	
-		// MCBB (Blend Batches)
-		0x4D434242: function(data, chunkSize) {
-			const count = chunkSize / 20;
-			const blend = this.blendBatches = new Array(count);
-	
-			for (let i = 0; i < count; i++) {
-				blend[i] = {
-					mbmhIndex: data.readUInt32LE(),
-					indexCount: data.readUInt32LE(),
-					indexFirst: data.readUInt32LE(),
-					vertexCount: data.readUInt32LE(),
-					vertexFirst: data.readUInt32LE()
-				};
-			}
+			// Ensure that we start at the next chunk exactly.
+			data.seek(nextChunkPos);
 		}
-	};
-	
-	const ADTTexChunkHandlers = {
-		// MVER (Version)
-		0x4D564552: function(data) {
-			this.version = data.readUInt32LE();
-			if (this.version !== 18)
-				throw new Error('Unexpected ADT version: ' + this.version);
-		},
-	
-		// MTEX (Textures)
-		0x4D544558: function(data, chunkSize) {
-			this.textures = LoaderGenerics.ReadStringBlock(data, chunkSize);
-		},
-	
-		// MCNK (Texture Chunks)
-		0x4D434E4B: function(data, chunkSize) {
-			const endOfs = data.offset + chunkSize;
-			const chunk = this.texChunks[this.chunkIndex++] = {};
-	
-			// Read sub-chunks.
-			while (data.offset < endOfs) {
-				const chunkID = data.readUInt32LE();
-				const subChunkSize = data.readUInt32LE();
-				const nextChunkPos = data.offset + subChunkSize;
-	
-				const handler = TexMCNKChunkHandlers[chunkID];
-				if (handler)
-					handler.call(chunk, data, subChunkSize, this.wdt);
-		
-				// Ensure that we start at the next chunk exactly.
-				data.seek(nextChunkPos);
-			}
-		},
-	
-		// MTXP
-		0x4D545850: function(data, chunkSize) {
-			const count = chunkSize / 16;
-			const params = this.texParams = new Array(count);
-	
-			for (let i = 0; i < count; i++) {
-				params[i] = {
-					flags: data.readUInt32LE(),
-					height: data.readFloatLE(),
-					offset: data.readFloatLE(),
-					unk3: data.readUInt32LE()
-				};
-			}
-		},
-	
-		// MHID
-		0x4D484944: function(data, chunkSize) {
-			this.heightTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
-		},
-	
-		// MDID
-		0x4D444944: function(data, chunkSize) {
-			this.diffuseTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
+	},
+
+	// MTXP
+	0x4D545850: function(data, chunkSize) {
+		const count = chunkSize / 16;
+		const params = this.texParams = new Array(count);
+
+		for (let i = 0; i < count; i++) {
+			params[i] = {
+				flags: data.readUInt32LE(),
+				height: data.readFloatLE(),
+				offset: data.readFloatLE(),
+				unk3: data.readUInt32LE()
+			};
 		}
-	};
-	
-	const TexMCNKChunkHandlers = {
-		// MCLY
-		0x4D434C59: function(data, chunkSize) {
-			const count = chunkSize / 16;
-			const layers = this.layers = new Array(count);
-	
-			for (let i = 0; i < count; i++) {
-				layers[i] = {
-					textureId: data.readUInt32LE(),
-					flags: data.readUInt32LE(),
-					offsetMCAL: data.readUInt32LE(),
-					effectID: data.readInt32LE()
-				};
-			}
-		},
-	
-		// MCAL
-		0x4D43414C: function(data, chunkSize, root) {
-			const layerCount = this.layers.length;
-			const alphaLayers = this.alphaLayers = new Array(layerCount);
-			alphaLayers[0] = new Array(64 * 64).fill(255);
-	
-			let ofs = 0;
-			for (let i = 1; i < layerCount; i++) {
-				const layer = this.layers[i];
-	
-				if (layer.offsetMCAL !== ofs)
-					throw new Error('MCAL offset mis-match');
-	
-				if (layer.flags & 0x200) {
-					// Compressed.
-					const alphaLayer = alphaLayers[i] = new Array(64 * 64);
-	
-					let inOfs = 0;
-					let outOfs = 0;
-	
-					while (outOfs < 4096) {
-						const info = data.readUInt8();
+	},
+
+	// MHID
+	0x4D484944: function(data, chunkSize) {
+		this.heightTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
+	},
+
+	// MDID
+	0x4D444944: function(data, chunkSize) {
+		this.diffuseTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
+	}
+};
+
+const TexMCNKChunkHandlers = {
+	// MCLY
+	0x4D434C59: function(data, chunkSize) {
+		const count = chunkSize / 16;
+		const layers = this.layers = new Array(count);
+
+		for (let i = 0; i < count; i++) {
+			layers[i] = {
+				textureId: data.readUInt32LE(),
+				flags: data.readUInt32LE(),
+				offsetMCAL: data.readUInt32LE(),
+				effectID: data.readInt32LE()
+			};
+		}
+	},
+
+	// MCAL
+	0x4D43414C: function(data, chunkSize, root) {
+		const layerCount = this.layers.length;
+		const alphaLayers = this.alphaLayers = new Array(layerCount);
+		alphaLayers[0] = new Array(64 * 64).fill(255);
+
+		let ofs = 0;
+		for (let i = 1; i < layerCount; i++) {
+			const layer = this.layers[i];
+
+			if (layer.offsetMCAL !== ofs)
+				throw new Error('MCAL offset mis-match');
+
+			if (layer.flags & 0x200) {
+				// Compressed.
+				const alphaLayer = alphaLayers[i] = new Array(64 * 64);
+
+				let inOfs = 0;
+				let outOfs = 0;
+
+				while (outOfs < 4096) {
+					const info = data.readUInt8();
+					inOfs++;
+
+					const mode = (info & 0x80) >> 7;
+					let count = (info & 0x7F);
+
+					if (mode !== 0) {
+						const value = data.readUInt8();
 						inOfs++;
-	
-						const mode = (info & 0x80) >> 7;
-						let count = (info & 0x7F);
-	
-						if (mode !== 0) {
+
+						while (count-- > 0 && outOfs < 4096) {
+							alphaLayer[outOfs] = value;
+							outOfs++;
+						}
+					} else {
+						while (count-- > 0 && outOfs < 4096) {
 							const value = data.readUInt8();
 							inOfs++;
-	
-							while (count-- > 0 && outOfs < 4096) {
-								alphaLayer[outOfs] = value;
-								outOfs++;
-							}
-						} else {
-							while (count-- > 0 && outOfs < 4096) {
-								const value = data.readUInt8();
-								inOfs++;
-	
-								alphaLayer[outOfs] = value;
-								outOfs++;
-							}
+
+							alphaLayer[outOfs] = value;
+							outOfs++;
 						}
 					}
-	
-					ofs += inOfs;
-					if (outOfs !== 4096)
-						throw new Error('Broken ADT.');
-				} else if (root.flags & 0x4 || root.flags & 0x80) {
-					// Uncompressed (4096)
-					alphaLayers[i] = data.readUInt8(4096);
-					ofs += 4096;
-				} else {
-					// Uncompressed (2048)
-					const alphaLayer = alphaLayers[i] = new Array(64 * 64);
-					const rawLayer = data.readUInt8(2048);
-					ofs += 2048;
-	
-					for (let j = 0; j < 2048; j++) {
-						alphaLayer[2 * j + 0] = ((rawLayer[j] & 0x0F) >> 0) * 17;
-						alphaLayer[2 * j + 1] = ((rawLayer[j] & 0xF0) >> 4) * 17;
-					}
-				} 
-			}
+				}
+
+				ofs += inOfs;
+				if (outOfs !== 4096)
+					throw new Error('Broken ADT.');
+			} else if (root.flags & 0x4 || root.flags & 0x80) {
+				// Uncompressed (4096)
+				alphaLayers[i] = data.readUInt8(4096);
+				ofs += 4096;
+			} else {
+				// Uncompressed (2048)
+				const alphaLayer = alphaLayers[i] = new Array(64 * 64);
+				const rawLayer = data.readUInt8(2048);
+				ofs += 2048;
+
+				for (let j = 0; j < 2048; j++) {
+					alphaLayer[2 * j + 0] = ((rawLayer[j] & 0x0F) >> 0) * 17;
+					alphaLayer[2 * j + 1] = ((rawLayer[j] & 0xF0) >> 4) * 17;
+				}
+			} 
 		}
-	};
-	
-	const ADTObjChunkHandlers = {
-		// MVER (Version)
-		0x4D564552: function(data) {
-			this.version = data.readUInt32LE();
-			if (this.version !== 18)
-				throw new Error('Unexpected ADT version: ' + this.version);
-		},
-	
-		// MMDX (Doodad Filenames)
-		0x4D4D4458: function(data, chunkSize) {
-			this.m2Names = LoaderGenerics.ReadStringBlock(data, chunkSize);
-		},
-	
-		// MMID (M2 Offsets)
-		0x4D4D4944: function(data, chunkSize) {
-			this.m2Offsets = data.readUInt32LE(chunkSize / 4);
-		},
-	
-		// MWMO (WMO Filenames)
-		0x4D574D4F: function(data, chunkSize) {
-			this.wmoNames = LoaderGenerics.ReadStringBlock(data, chunkSize);
-		},
-	
-		// MWID (WMO Offsets)
-		0x4D574944: function(data, chunkSize) {
-			this.wmoOffsets = data.readUInt32LE(chunkSize / 4);
-		},
-	
-		// MDDF
-		0x4D444446: function(data, chunkSize) {
-			const count = chunkSize / 36;
-			const entries = this.models = new Array(count);
-	
-			for (let i = 0; i < count; i++) {
-				entries[i] = {
-					mmidEntry: data.readUInt32LE(),
-					uniqueId: data.readUInt32LE(),
-					position: data.readFloatLE(3),
-					rotation: data.readFloatLE(3),
-					scale: data.readUInt16LE(),
-					flags: data.readUInt16LE()
-				};
-			}
-		},
-	
-		// MODF
-		0x4D4F4446: function(data, chunkSize) {
-			const count = chunkSize / 64;
-			const entries = this.worldModels = new Array(count);
-	
-			for (let i = 0; i < count; i++) {
-				entries[i] = {
-					mwidEntry: data.readUInt32LE(),
-					uniqueId: data.readUInt32LE(),
-					position: data.readFloatLE(3),
-					rotation: data.readFloatLE(3),
-					lowerBounds: data.readFloatLE(3),
-					upperBounds: data.readFloatLE(3),
-					flags: data.readUInt16LE(),
-					doodadSet: data.readUInt16LE(),
-					nameSet: data.readUInt16LE(),
-					scale: data.readUInt16LE()
-				};
-			}
-		},
-	
-		// MWDS
-		0x4D574453: function(data, chunkSize) {
-			this.doodadSets = data.readUInt16LE(chunkSize / 2);
+	}
+};
+
+const ADTObjChunkHandlers = {
+	// MVER (Version)
+	0x4D564552: function(data) {
+		this.version = data.readUInt32LE();
+		if (this.version !== 18)
+			throw new Error('Unexpected ADT version: ' + this.version);
+	},
+
+	// MMDX (Doodad Filenames)
+	0x4D4D4458: function(data, chunkSize) {
+		this.m2Names = LoaderGenerics.ReadStringBlock(data, chunkSize);
+	},
+
+	// MMID (M2 Offsets)
+	0x4D4D4944: function(data, chunkSize) {
+		this.m2Offsets = data.readUInt32LE(chunkSize / 4);
+	},
+
+	// MWMO (WMO Filenames)
+	0x4D574D4F: function(data, chunkSize) {
+		this.wmoNames = LoaderGenerics.ReadStringBlock(data, chunkSize);
+	},
+
+	// MWID (WMO Offsets)
+	0x4D574944: function(data, chunkSize) {
+		this.wmoOffsets = data.readUInt32LE(chunkSize / 4);
+	},
+
+	// MDDF
+	0x4D444446: function(data, chunkSize) {
+		const count = chunkSize / 36;
+		const entries = this.models = new Array(count);
+
+		for (let i = 0; i < count; i++) {
+			entries[i] = {
+				mmidEntry: data.readUInt32LE(),
+				uniqueId: data.readUInt32LE(),
+				position: data.readFloatLE(3),
+				rotation: data.readFloatLE(3),
+				scale: data.readUInt16LE(),
+				flags: data.readUInt16LE()
+			};
 		}
-	};
-	
-	module.exports = ADTLoader;
+	},
+
+	// MODF
+	0x4D4F4446: function(data, chunkSize) {
+		const count = chunkSize / 64;
+		const entries = this.worldModels = new Array(count);
+
+		for (let i = 0; i < count; i++) {
+			entries[i] = {
+				mwidEntry: data.readUInt32LE(),
+				uniqueId: data.readUInt32LE(),
+				position: data.readFloatLE(3),
+				rotation: data.readFloatLE(3),
+				lowerBounds: data.readFloatLE(3),
+				upperBounds: data.readFloatLE(3),
+				flags: data.readUInt16LE(),
+				doodadSet: data.readUInt16LE(),
+				nameSet: data.readUInt16LE(),
+				scale: data.readUInt16LE()
+			};
+		}
+	},
+
+	// MWDS
+	0x4D574453: function(data, chunkSize) {
+		this.doodadSets = data.readUInt16LE(chunkSize / 2);
+	}
+};
+
+module.exports = ADTLoader;

--- a/src/js/3D/loaders/ADTLoader.js
+++ b/src/js/3D/loaders/ADTLoader.js
@@ -3,512 +3,515 @@
 	Authors: Kruithne <kruithne@gmail.com>
 	License: MIT
  */
-const LoaderGenerics = require('./LoaderGenerics');
+	const LoaderGenerics = require('./LoaderGenerics');
 
-class ADTLoader {
-	/**
-	 * Construct a new ADTLoader instance.
-	 * @param {BufferWrapper} data 
-	 */
-	constructor(data) {
-		this.data = data;
-	}
-
-	/**
-	 * Parse this ADT as a root file.
-	 */
-	loadRoot() {
-		this.chunks = new Array(16 * 16);
-		this.chunkIndex = 0;
-
-		this.handlers = ADTChunkHandlers;
-		this._load();
-	}
-
-	/**
-	 * Parse this ADT as an object file.
-	 */
-	loadObj() {
-		this.handlers = ADTObjChunkHandlers;
-		this._load();
-	}
-
-	/**
-	 * Parse this ADT as a texture file.
-	 * @param {WDTLoader} wdt
-	 */
-	loadTex(wdt) {
-		this.texChunks = new Array(16 * 16);
-		this.chunkIndex = 0;
-		this.wdt = wdt;
-
-		this.handlers = ADTTexChunkHandlers;
-		this._load();
-	}
-
-	/**
-	 * Load the ADT file, parsing it.
-	 */
-	_load() {
-		while (this.data.remainingBytes > 0) {
-			const chunkID = this.data.readUInt32LE();
-			const chunkSize = this.data.readUInt32LE();
-			const nextChunkPos = this.data.offset + chunkSize;
-
-			const handler = this.handlers[chunkID];
-			if (handler)
-				handler.call(this, this.data, chunkSize);
+	class ADTLoader {
+		/**
+		 * Construct a new ADTLoader instance.
+		 * @param {BufferWrapper} data 
+		 */
+		constructor(data) {
+			this.data = data;
+		}
 	
-			// Ensure that we start at the next chunk exactly.
-			this.data.seek(nextChunkPos);
+		/**
+		 * Parse this ADT as a root file.
+		 */
+		loadRoot() {
+			this.chunks = new Array(16 * 16);
+			this.chunkIndex = 0;
+	
+			this.handlers = ADTChunkHandlers;
+			this._load();
+		}
+	
+		/**
+		 * Parse this ADT as an object file.
+		 */
+		loadObj() {
+			this.handlers = ADTObjChunkHandlers;
+			this._load();
+		}
+	
+		/**
+		 * Parse this ADT as a texture file.
+		 * @param {WDTLoader} wdt
+		 */
+		loadTex(wdt) {
+			this.texChunks = new Array(16 * 16);
+			this.chunkIndex = 0;
+			this.wdt = wdt;
+	
+			this.handlers = ADTTexChunkHandlers;
+			this._load();
+		}
+	
+		/**
+		 * Load the ADT file, parsing it.
+		 */
+		_load() {
+			while (this.data.remainingBytes > 0) {
+				const chunkID = this.data.readUInt32LE();
+				const chunkSize = this.data.readUInt32LE();
+				const nextChunkPos = this.data.offset + chunkSize;
+	
+				const handler = this.handlers[chunkID];
+				if (handler)
+					handler.call(this, this.data, chunkSize);
+		
+				// Ensure that we start at the next chunk exactly.
+				this.data.seek(nextChunkPos);
+			}
 		}
 	}
-}
-
-const ADTChunkHandlers = {
-	// MVER (Version)
-	0x4D564552: function(data) {
-		this.version = data.readUInt32LE();
-		if (this.version !== 18)
-			throw new Error('Unexpected ADT version: ' + this.version);
-	},
-
-	// MCNK
-	0x4D434E4B: function(data, chunkSize) {
-		const endOfs = data.offset + chunkSize;
-		const chunk = this.chunks[this.chunkIndex++] = {
-			flags: data.readUInt32LE(),
-			indexX: data.readUInt32LE(),
-			indexY: data.readUInt32LE(),
-			nLayers: data.readUInt32LE(),
-			nDoodadRefs: data.readUInt32LE(),
-			holesHighRes: data.readUInt8(8),
-			ofsMCLY: data.readUInt32LE(),
-			ofsMCRF: data.readUInt32LE(),
-			ofsMCAL: data.readUInt32LE(),
-			sizeAlpha: data.readUInt32LE(),
-			ofsMCSH: data.readUInt32LE(),
-			sizeShadows: data.readUInt32LE(),
-			areaID: data.readUInt32LE(),
-			nMapObjRefs: data.readUInt32LE(),
-			holesLowRes: data.readUInt16LE(),
-			unk1: data.readUInt16LE(),
-			lowQualityTextureMap: data.readInt16LE(8),
-			noEffectDoodad: data.readInt64LE(),
-			ofsMCSE: data.readUInt32LE(),
-			numMCSE: data.readUInt32LE(),
-			ofsMCLQ: data.readUInt32LE(),
-			sizeMCLQ: data.readUInt32LE(),
-			position: data.readFloatLE(3),
-			ofsMCCV: data.readUInt32LE(),
-			ofsMCLW: data.readUInt32LE(),
-			unk2: data.readUInt32LE()
-		};
-
-		// Read sub-chunks.
-		while (data.offset < endOfs) {
-			const chunkID = data.readUInt32LE();
-			const subChunkSize = data.readUInt32LE();
-			const nextChunkPos = data.offset + subChunkSize;
-
-			const handler = RootMCNKChunkHandlers[chunkID];
-			if (handler)
-				handler.call(chunk, data, subChunkSize);
 	
-			// Ensure that we start at the next chunk exactly.
-			data.seek(nextChunkPos);
-		}
-	},
-
-	// MH2O (Liquids)
-	0x4D48324F: function(data) {
-		const base = data.offset;
-		let dataOffsets = new Set();
-
-		// SMLiquidChunk
-		const chunks = this.liquidChunks = new Array(256);
-		for (let i = 0; i < 256; i++) {
-			const offsetInstances = data.readUInt32LE();
-			const layerCount = data.readUInt32LE();
-			const offsetAttributes = data.readUInt32LE();
-
-			if (offsetAttributes > 0)
-				dataOffsets.add(offsetAttributes);
-
-			const entryOfs = data.offset;
-			const chunk = chunks[i] = {
-				attributes: { fishable: 0, deep: 0 },
-				instances: new Array(layerCount)
+	const ADTChunkHandlers = {
+		// MVER (Version)
+		0x4D564552: function(data) {
+			this.version = data.readUInt32LE();
+			if (this.version !== 18)
+				throw new Error('Unexpected ADT version: ' + this.version);
+		},
+	
+		// MCNK
+		0x4D434E4B: function(data, chunkSize) {
+			const endOfs = data.offset + chunkSize;
+			const chunk = this.chunks[this.chunkIndex++] = {
+				flags: data.readUInt32LE(),
+				indexX: data.readUInt32LE(),
+				indexY: data.readUInt32LE(),
+				nLayers: data.readUInt32LE(),
+				nDoodadRefs: data.readUInt32LE(),
+				holesHighRes: data.readUInt8(8),
+				ofsMCLY: data.readUInt32LE(),
+				ofsMCRF: data.readUInt32LE(),
+				ofsMCAL: data.readUInt32LE(),
+				sizeAlpha: data.readUInt32LE(),
+				ofsMCSH: data.readUInt32LE(),
+				sizeShadows: data.readUInt32LE(),
+				areaID: data.readUInt32LE(),
+				nMapObjRefs: data.readUInt32LE(),
+				holesLowRes: data.readUInt16LE(),
+				unk1: data.readUInt16LE(),
+				lowQualityTextureMap: data.readInt16LE(8),
+				noEffectDoodad: data.readInt64LE(),
+				ofsMCSE: data.readUInt32LE(),
+				numMCSE: data.readUInt32LE(),
+				ofsMCLQ: data.readUInt32LE(),
+				sizeMCLQ: data.readUInt32LE(),
+				position: data.readFloatLE(3),
+				ofsMCCV: data.readUInt32LE(),
+				ofsMCLW: data.readUInt32LE(),
+				unk2: data.readUInt32LE()
 			};
-
-			if (layerCount > 0) {
-				// Read chunk attributes.
-				data.seek(base + offsetAttributes);
-				chunk.attributes.fishable = data.readUInt64LE();
-				chunk.attributes.deep = data.readUInt64LE();
-
-				// Read SMLiquidInstance array.
-				data.seek(base + offsetInstances);
-				for (let j = 0; j < layerCount; j++) {
-					const instance = chunk.instances[j] = {
-						liquidType: data.readUInt16LE(),
-						liquidObject: data.readUInt16LE(),
-						minHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
-						maxHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
-						xOffset: data.readUInt8(), // 0 if liquidObject <= 41
-						yOffset: data.readUInt8(), // 0 if liquidObject <= 41
-						width: data.readUInt8(), // 8 if liquidObject <= 41
-						height: data.readUInt8(), // 8 if liquidObject <= 41
-						bitmap: [], // Empty == All exist.
-						vertexData: {},
-						offsetExistsBitmap: data.readUInt32LE(),
-						offsetVertexData: data.readUInt32LE()
-					};
-
-					if (instance.offsetExistsBitmap > 0)
-						dataOffsets.add(instance.offsetExistsBitmap);
-
-					if (instance.offsetVertexData > 0)
-						dataOffsets.add(instance.offsetVertexData);
-
-					const instanceOfs = data.offset;
-
-					// Rounding up to cover all necessary bytes for the bitmap here. Probably correct?
-					if (instance.offsetExistsBitmap > 0)
-						instance.bitmap = data.readUInt8(Math.ceil((instance.width * instance.height + 7) / 8));
-
-					data.seek(instanceOfs);
+	
+			// Read sub-chunks.
+			while (data.offset < endOfs) {
+				const chunkID = data.readUInt32LE();
+				const subChunkSize = data.readUInt32LE();
+				const nextChunkPos = data.offset + subChunkSize;
+	
+				const handler = RootMCNKChunkHandlers[chunkID];
+				if (handler)
+					handler.call(chunk, data, subChunkSize);
+		
+				// Ensure that we start at the next chunk exactly.
+				data.seek(nextChunkPos);
+			}
+		},
+	
+		// MH2O (Liquids)
+		0x4D48324F: function(data) {
+			const base = data.offset;
+			let dataOffsets = new Set();
+	
+			// SMLiquidChunk
+			const chunks = this.liquidChunks = new Array(256);
+			for (let i = 0; i < 256; i++) {
+				const offsetInstances = data.readUInt32LE();
+				const layerCount = data.readUInt32LE();
+				const offsetAttributes = data.readUInt32LE();
+	
+				if (offsetAttributes > 0)
+					dataOffsets.add(offsetAttributes);
+	
+				const entryOfs = data.offset;
+				const chunk = chunks[i] = {
+					attributes: { fishable: 0, deep: 0 },
+					instances: new Array(layerCount)
+				};
+	
+				if (layerCount > 0) {
+					// Read chunk attributes.
+					data.seek(base + offsetAttributes);
+					chunk.attributes.fishable = data.readUInt64LE();
+					chunk.attributes.deep = data.readUInt64LE();
+	
+					// Read SMLiquidInstance array.
+					data.seek(base + offsetInstances);
+					for (let j = 0; j < layerCount; j++) {
+						const instance = chunk.instances[j] = {
+							liquidType: data.readUInt16LE(),
+							liquidObject: data.readUInt16LE(),
+							minHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
+							maxHeightLevel: data.readFloatLE(), // Use 0.0 if LVF = 2
+							xOffset: data.readUInt8(), // 0 if liquidObject <= 41
+							yOffset: data.readUInt8(), // 0 if liquidObject <= 41
+							width: data.readUInt8(), // 8 if liquidObject <= 41
+							height: data.readUInt8(), // 8 if liquidObject <= 41
+							bitmap: [], // Empty == All exist.
+							vertexData: {},
+							offsetExistsBitmap: data.readUInt32LE(),
+							offsetVertexData: data.readUInt32LE()
+						};
+	
+						if (instance.offsetExistsBitmap > 0)
+							dataOffsets.add(instance.offsetExistsBitmap);
+	
+						if (instance.offsetVertexData > 0)
+							dataOffsets.add(instance.offsetVertexData);
+	
+						const instanceOfs = data.offset;
+	
+						if (instance.offsetExistsBitmap > 0)
+						{
+							data.seek(base + instance.offsetExistsBitmap);
+							const bitmapDataLength = Math.floor((instance.width * instance.height + 7) / 8);
+							instance.bitmap = data.readUInt8(bitmapDataLength);
+						}
+						
+						data.seek(instanceOfs);
+					}
+				}
+	
+				data.seek(entryOfs);
+			}
+	
+			dataOffsets = Array.from(dataOffsets).sort((a, b) => a - b);
+	
+			// Retroactively parse vertex data by assuming the structures based on offsets.
+			for (const chunk of chunks) {
+				for (const instance of chunk.instances) {
+					if (instance.offsetVertexData > 0) {
+						const vertexCount = (instance.width + 1) * (instance.height + 1);
+						const ofsIndex = dataOffsets.indexOf(instance.offsetVertexData);
+						const dataSize = dataOffsets[ofsIndex + 1] - instance.offsetVertexData;
+	
+						data.seek(base + instance.offsetVertexData);
+	
+						const mtp = dataSize / vertexCount;
+						const vertexData = instance.vertexData = {};
+	
+						// MTP
+						// 5 = Height, Depth
+						// 8 = Height, UV
+						// 1 = Depth
+						// 9 = Height, UV, Depth
+	
+						// Height
+						if (mtp === 5 || mtp === 8 || mtp === 9)
+							vertexData.height = data.readFloatLE(vertexCount);
+	
+						// Texture Coordinates (UV)
+						if (mtp === 8 || mtp === 9) {
+							const uv = vertexData.uv = new Array(vertexCount);
+							for (let i = 0; i < vertexCount; i++) {
+								uv[i] = {
+									x: data.readUInt16LE(),
+									y: data.readUInt16LE()
+								}
+							}
+						}
+	
+						// Depth
+						if (mtp === 5 || mtp === 1 || mtp === 9)
+							vertexData.depth = data.readUInt8(vertexCount);
+					}
 				}
 			}
-
-			data.seek(entryOfs);
+		},
+	
+		// MHDR (Header)
+		0x4D484452: function(data) {
+			this.header = {
+				flags: data.readUInt32LE(),
+				ofsMCIN: data.readUInt32LE(),
+				ofsMTEX: data.readUInt32LE(),
+				ofsMMDX: data.readUInt32LE(),
+				ofsMMID: data.readUInt32LE(),
+				ofsMWMO: data.readUInt32LE(),
+				ofsMWID: data.readUInt32LE(),
+				ofsMDDF: data.readUInt32LE(),
+				ofsMODF: data.readUInt32LE(),
+				ofsMFBO: data.readUInt32LE(),
+				ofsMH20: data.readUInt32LE(),
+				ofsMTXF: data.readUInt32LE(),
+				unk: data.readUInt32LE(4)
+			};
 		}
-
-		dataOffsets = Array.from(dataOffsets).sort((a, b) => a - b);
-
-		// Retroactively parse vertex data by assuming the structures based on offsets.
-		for (const chunk of chunks) {
-			for (const instance of chunk.instances) {
-				if (instance.offsetVertexData > 0) {
-					const vertexCount = (instance.width + 1) * (instance.height + 1);
-					const ofsIndex = dataOffsets.indexOf(instance.offsetVertexData);
-					const dataSize = dataOffsets[ofsIndex + 1] - instance.offsetVertexData;
-
-					data.seek(base + instance.offsetVertexData);
-
-					const mtp = dataSize / vertexCount;
-					const vertexData = instance.vertexData = {};
-
-					// MTP
-					// 5 = Height, Depth
-					// 8 = Height, UV
-					// 1 = Depth
-					// 9 = Height, UV, Depth
-
-					// Height
-					if (mtp === 5 || mtp === 8 || mtp === 9)
-						vertexData.height = data.readFloatLE(vertexCount);
-
-					// Texture Coordinates (UV)
-					if (mtp === 8 || mtp === 9) {
-						const uv = vertexData.uv = new Array(vertexCount);
-						for (let i = 0; i < vertexCount; i++) {
-							uv[i] = {
-								x: data.readUInt16LE(),
-								y: data.readUInt16LE()
+	};
+	
+	const RootMCNKChunkHandlers = {
+		// MCVT (vertices)
+		0x4D435654: function(data) {
+			this.vertices = data.readFloatLE(145);
+		},
+	
+		// MCCV (Vertex Shading)
+		0x4D434356: function(data) {
+			const shading = this.vertexShading = new Array(145);
+			for (let i = 0; i < 145; i++) {
+				shading[i] = {
+					r: data.readUInt8(),
+					g: data.readUInt8(),
+					b: data.readUInt8(),
+					a: data.readUInt8()
+				}
+			}
+		},
+	
+		// MCNR (Normals)
+		0x4D434E52: function(data) {
+			const normals = this.normals = new Array(145);
+			for (let i = 0; i < 145; i++) {
+				const x = data.readInt8();
+				const z = data.readInt8();
+				const y = data.readInt8();
+	
+				normals[i] = [x, y, z];
+			}
+		},
+	
+		// MCBB (Blend Batches)
+		0x4D434242: function(data, chunkSize) {
+			const count = chunkSize / 20;
+			const blend = this.blendBatches = new Array(count);
+	
+			for (let i = 0; i < count; i++) {
+				blend[i] = {
+					mbmhIndex: data.readUInt32LE(),
+					indexCount: data.readUInt32LE(),
+					indexFirst: data.readUInt32LE(),
+					vertexCount: data.readUInt32LE(),
+					vertexFirst: data.readUInt32LE()
+				};
+			}
+		}
+	};
+	
+	const ADTTexChunkHandlers = {
+		// MVER (Version)
+		0x4D564552: function(data) {
+			this.version = data.readUInt32LE();
+			if (this.version !== 18)
+				throw new Error('Unexpected ADT version: ' + this.version);
+		},
+	
+		// MTEX (Textures)
+		0x4D544558: function(data, chunkSize) {
+			this.textures = LoaderGenerics.ReadStringBlock(data, chunkSize);
+		},
+	
+		// MCNK (Texture Chunks)
+		0x4D434E4B: function(data, chunkSize) {
+			const endOfs = data.offset + chunkSize;
+			const chunk = this.texChunks[this.chunkIndex++] = {};
+	
+			// Read sub-chunks.
+			while (data.offset < endOfs) {
+				const chunkID = data.readUInt32LE();
+				const subChunkSize = data.readUInt32LE();
+				const nextChunkPos = data.offset + subChunkSize;
+	
+				const handler = TexMCNKChunkHandlers[chunkID];
+				if (handler)
+					handler.call(chunk, data, subChunkSize, this.wdt);
+		
+				// Ensure that we start at the next chunk exactly.
+				data.seek(nextChunkPos);
+			}
+		},
+	
+		// MTXP
+		0x4D545850: function(data, chunkSize) {
+			const count = chunkSize / 16;
+			const params = this.texParams = new Array(count);
+	
+			for (let i = 0; i < count; i++) {
+				params[i] = {
+					flags: data.readUInt32LE(),
+					height: data.readFloatLE(),
+					offset: data.readFloatLE(),
+					unk3: data.readUInt32LE()
+				};
+			}
+		},
+	
+		// MHID
+		0x4D484944: function(data, chunkSize) {
+			this.heightTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
+		},
+	
+		// MDID
+		0x4D444944: function(data, chunkSize) {
+			this.diffuseTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
+		}
+	};
+	
+	const TexMCNKChunkHandlers = {
+		// MCLY
+		0x4D434C59: function(data, chunkSize) {
+			const count = chunkSize / 16;
+			const layers = this.layers = new Array(count);
+	
+			for (let i = 0; i < count; i++) {
+				layers[i] = {
+					textureId: data.readUInt32LE(),
+					flags: data.readUInt32LE(),
+					offsetMCAL: data.readUInt32LE(),
+					effectID: data.readInt32LE()
+				};
+			}
+		},
+	
+		// MCAL
+		0x4D43414C: function(data, chunkSize, root) {
+			const layerCount = this.layers.length;
+			const alphaLayers = this.alphaLayers = new Array(layerCount);
+			alphaLayers[0] = new Array(64 * 64).fill(255);
+	
+			let ofs = 0;
+			for (let i = 1; i < layerCount; i++) {
+				const layer = this.layers[i];
+	
+				if (layer.offsetMCAL !== ofs)
+					throw new Error('MCAL offset mis-match');
+	
+				if (layer.flags & 0x200) {
+					// Compressed.
+					const alphaLayer = alphaLayers[i] = new Array(64 * 64);
+	
+					let inOfs = 0;
+					let outOfs = 0;
+	
+					while (outOfs < 4096) {
+						const info = data.readUInt8();
+						inOfs++;
+	
+						const mode = (info & 0x80) >> 7;
+						let count = (info & 0x7F);
+	
+						if (mode !== 0) {
+							const value = data.readUInt8();
+							inOfs++;
+	
+							while (count-- > 0 && outOfs < 4096) {
+								alphaLayer[outOfs] = value;
+								outOfs++;
+							}
+						} else {
+							while (count-- > 0 && outOfs < 4096) {
+								const value = data.readUInt8();
+								inOfs++;
+	
+								alphaLayer[outOfs] = value;
+								outOfs++;
 							}
 						}
 					}
-
-					// Depth
-					if (mtp === 5 || mtp === 1 || mtp === 9)
-						vertexData.depth = data.readUInt8(vertexCount);
-				}
-			}
-		}
-	},
-
-	// MHDR (Header)
-	0x4D484452: function(data) {
-		this.header = {
-			flags: data.readUInt32LE(),
-			ofsMCIN: data.readUInt32LE(),
-			ofsMTEX: data.readUInt32LE(),
-			ofsMMDX: data.readUInt32LE(),
-			ofsMMID: data.readUInt32LE(),
-			ofsMWMO: data.readUInt32LE(),
-			ofsMWID: data.readUInt32LE(),
-			ofsMDDF: data.readUInt32LE(),
-			ofsMODF: data.readUInt32LE(),
-			ofsMFBO: data.readUInt32LE(),
-			ofsMH20: data.readUInt32LE(),
-			ofsMTXF: data.readUInt32LE(),
-			unk: data.readUInt32LE(4)
-		};
-	}
-};
-
-const RootMCNKChunkHandlers = {
-	// MCVT (vertices)
-	0x4D435654: function(data) {
-		this.vertices = data.readFloatLE(145);
-	},
-
-	// MCCV (Vertex Shading)
-	0x4D434356: function(data) {
-		const shading = this.vertexShading = new Array(145);
-		for (let i = 0; i < 145; i++) {
-			shading[i] = {
-				r: data.readUInt8(),
-				g: data.readUInt8(),
-				b: data.readUInt8(),
-				a: data.readUInt8()
-			}
-		}
-	},
-
-	// MCNR (Normals)
-	0x4D434E52: function(data) {
-		const normals = this.normals = new Array(145);
-		for (let i = 0; i < 145; i++) {
-			const x = data.readInt8();
-			const z = data.readInt8();
-			const y = data.readInt8();
-
-			normals[i] = [x, y, z];
-		}
-	},
-
-	// MCBB (Blend Batches)
-	0x4D434242: function(data, chunkSize) {
-		const count = chunkSize / 20;
-		const blend = this.blendBatches = new Array(count);
-
-		for (let i = 0; i < count; i++) {
-			blend[i] = {
-				mbmhIndex: data.readUInt32LE(),
-				indexCount: data.readUInt32LE(),
-				indexFirst: data.readUInt32LE(),
-				vertexCount: data.readUInt32LE(),
-				vertexFirst: data.readUInt32LE()
-			};
-		}
-	}
-};
-
-const ADTTexChunkHandlers = {
-	// MVER (Version)
-	0x4D564552: function(data) {
-		this.version = data.readUInt32LE();
-		if (this.version !== 18)
-			throw new Error('Unexpected ADT version: ' + this.version);
-	},
-
-	// MTEX (Textures)
-	0x4D544558: function(data, chunkSize) {
-		this.textures = LoaderGenerics.ReadStringBlock(data, chunkSize);
-	},
-
-	// MCNK (Texture Chunks)
-	0x4D434E4B: function(data, chunkSize) {
-		const endOfs = data.offset + chunkSize;
-		const chunk = this.texChunks[this.chunkIndex++] = {};
-
-		// Read sub-chunks.
-		while (data.offset < endOfs) {
-			const chunkID = data.readUInt32LE();
-			const subChunkSize = data.readUInt32LE();
-			const nextChunkPos = data.offset + subChunkSize;
-
-			const handler = TexMCNKChunkHandlers[chunkID];
-			if (handler)
-				handler.call(chunk, data, subChunkSize, this.wdt);
 	
-			// Ensure that we start at the next chunk exactly.
-			data.seek(nextChunkPos);
-		}
-	},
-
-	// MTXP
-	0x4D545850: function(data, chunkSize) {
-		const count = chunkSize / 16;
-		const params = this.texParams = new Array(count);
-
-		for (let i = 0; i < count; i++) {
-			params[i] = {
-				flags: data.readUInt32LE(),
-				height: data.readFloatLE(),
-				offset: data.readFloatLE(),
-				unk3: data.readUInt32LE()
-			};
-		}
-	},
-
-	// MHID
-	0x4D484944: function(data, chunkSize) {
-		this.heightTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
-	},
-
-	// MDID
-	0x4D444944: function(data, chunkSize) {
-		this.diffuseTextureFileDataIDs = data.readUInt32LE(chunkSize / 4);
-	}
-};
-
-const TexMCNKChunkHandlers = {
-	// MCLY
-	0x4D434C59: function(data, chunkSize) {
-		const count = chunkSize / 16;
-		const layers = this.layers = new Array(count);
-
-		for (let i = 0; i < count; i++) {
-			layers[i] = {
-				textureId: data.readUInt32LE(),
-				flags: data.readUInt32LE(),
-				offsetMCAL: data.readUInt32LE(),
-				effectID: data.readInt32LE()
-			};
-		}
-	},
-
-	// MCAL
-	0x4D43414C: function(data, chunkSize, root) {
-		const layerCount = this.layers.length;
-		const alphaLayers = this.alphaLayers = new Array(layerCount);
-		alphaLayers[0] = new Array(64 * 64).fill(255);
-
-		let ofs = 0;
-		for (let i = 1; i < layerCount; i++) {
-			const layer = this.layers[i];
-
-			if (layer.offsetMCAL !== ofs)
-				throw new Error('MCAL offset mis-match');
-
-			if (layer.flags & 0x200) {
-				// Compressed.
-				const alphaLayer = alphaLayers[i] = new Array(64 * 64);
-
-				let inOfs = 0;
-				let outOfs = 0;
-
-				while (outOfs < 4096) {
-					const info = data.readUInt8();
-					inOfs++;
-
-					const mode = (info & 0x80) >> 7;
-					let count = (info & 0x7F);
-
-					if (mode !== 0) {
-						const value = data.readUInt8();
-						inOfs++;
-
-						while (count-- > 0 && outOfs < 4096) {
-							alphaLayer[outOfs] = value;
-							outOfs++;
-						}
-					} else {
-						while (count-- > 0 && outOfs < 4096) {
-							const value = data.readUInt8();
-							inOfs++;
-
-							alphaLayer[outOfs] = value;
-							outOfs++;
-						}
+					ofs += inOfs;
+					if (outOfs !== 4096)
+						throw new Error('Broken ADT.');
+				} else if (root.flags & 0x4 || root.flags & 0x80) {
+					// Uncompressed (4096)
+					alphaLayers[i] = data.readUInt8(4096);
+					ofs += 4096;
+				} else {
+					// Uncompressed (2048)
+					const alphaLayer = alphaLayers[i] = new Array(64 * 64);
+					const rawLayer = data.readUInt8(2048);
+					ofs += 2048;
+	
+					for (let j = 0; j < 2048; j++) {
+						alphaLayer[2 * j + 0] = ((rawLayer[j] & 0x0F) >> 0) * 17;
+						alphaLayer[2 * j + 1] = ((rawLayer[j] & 0xF0) >> 4) * 17;
 					}
-				}
-
-				ofs += inOfs;
-				if (outOfs !== 4096)
-					throw new Error('Broken ADT.');
-			} else if (root.flags & 0x4 || root.flags & 0x80) {
-				// Uncompressed (4096)
-				alphaLayers[i] = data.readUInt8(4096);
-				ofs += 4096;
-			} else {
-				// Uncompressed (2048)
-				const alphaLayer = alphaLayers[i] = new Array(64 * 64);
-				const rawLayer = data.readUInt8(2048);
-				ofs += 2048;
-
-				for (let j = 0; j < 2048; j++) {
-					alphaLayer[2 * j + 0] = ((rawLayer[j] & 0x0F) >> 0) * 17;
-					alphaLayer[2 * j + 1] = ((rawLayer[j] & 0xF0) >> 4) * 17;
-				}
-			} 
+				} 
+			}
 		}
-	}
-};
-
-const ADTObjChunkHandlers = {
-	// MVER (Version)
-	0x4D564552: function(data) {
-		this.version = data.readUInt32LE();
-		if (this.version !== 18)
-			throw new Error('Unexpected ADT version: ' + this.version);
-	},
-
-	// MMDX (Doodad Filenames)
-	0x4D4D4458: function(data, chunkSize) {
-		this.m2Names = LoaderGenerics.ReadStringBlock(data, chunkSize);
-	},
-
-	// MMID (M2 Offsets)
-	0x4D4D4944: function(data, chunkSize) {
-		this.m2Offsets = data.readUInt32LE(chunkSize / 4);
-	},
-
-	// MWMO (WMO Filenames)
-	0x4D574D4F: function(data, chunkSize) {
-		this.wmoNames = LoaderGenerics.ReadStringBlock(data, chunkSize);
-	},
-
-	// MWID (WMO Offsets)
-	0x4D574944: function(data, chunkSize) {
-		this.wmoOffsets = data.readUInt32LE(chunkSize / 4);
-	},
-
-	// MDDF
-	0x4D444446: function(data, chunkSize) {
-		const count = chunkSize / 36;
-		const entries = this.models = new Array(count);
-
-		for (let i = 0; i < count; i++) {
-			entries[i] = {
-				mmidEntry: data.readUInt32LE(),
-				uniqueId: data.readUInt32LE(),
-				position: data.readFloatLE(3),
-				rotation: data.readFloatLE(3),
-				scale: data.readUInt16LE(),
-				flags: data.readUInt16LE()
-			};
+	};
+	
+	const ADTObjChunkHandlers = {
+		// MVER (Version)
+		0x4D564552: function(data) {
+			this.version = data.readUInt32LE();
+			if (this.version !== 18)
+				throw new Error('Unexpected ADT version: ' + this.version);
+		},
+	
+		// MMDX (Doodad Filenames)
+		0x4D4D4458: function(data, chunkSize) {
+			this.m2Names = LoaderGenerics.ReadStringBlock(data, chunkSize);
+		},
+	
+		// MMID (M2 Offsets)
+		0x4D4D4944: function(data, chunkSize) {
+			this.m2Offsets = data.readUInt32LE(chunkSize / 4);
+		},
+	
+		// MWMO (WMO Filenames)
+		0x4D574D4F: function(data, chunkSize) {
+			this.wmoNames = LoaderGenerics.ReadStringBlock(data, chunkSize);
+		},
+	
+		// MWID (WMO Offsets)
+		0x4D574944: function(data, chunkSize) {
+			this.wmoOffsets = data.readUInt32LE(chunkSize / 4);
+		},
+	
+		// MDDF
+		0x4D444446: function(data, chunkSize) {
+			const count = chunkSize / 36;
+			const entries = this.models = new Array(count);
+	
+			for (let i = 0; i < count; i++) {
+				entries[i] = {
+					mmidEntry: data.readUInt32LE(),
+					uniqueId: data.readUInt32LE(),
+					position: data.readFloatLE(3),
+					rotation: data.readFloatLE(3),
+					scale: data.readUInt16LE(),
+					flags: data.readUInt16LE()
+				};
+			}
+		},
+	
+		// MODF
+		0x4D4F4446: function(data, chunkSize) {
+			const count = chunkSize / 64;
+			const entries = this.worldModels = new Array(count);
+	
+			for (let i = 0; i < count; i++) {
+				entries[i] = {
+					mwidEntry: data.readUInt32LE(),
+					uniqueId: data.readUInt32LE(),
+					position: data.readFloatLE(3),
+					rotation: data.readFloatLE(3),
+					lowerBounds: data.readFloatLE(3),
+					upperBounds: data.readFloatLE(3),
+					flags: data.readUInt16LE(),
+					doodadSet: data.readUInt16LE(),
+					nameSet: data.readUInt16LE(),
+					scale: data.readUInt16LE()
+				};
+			}
+		},
+	
+		// MWDS
+		0x4D574453: function(data, chunkSize) {
+			this.doodadSets = data.readUInt16LE(chunkSize / 2);
 		}
-	},
-
-	// MODF
-	0x4D4F4446: function(data, chunkSize) {
-		const count = chunkSize / 64;
-		const entries = this.worldModels = new Array(count);
-
-		for (let i = 0; i < count; i++) {
-			entries[i] = {
-				mwidEntry: data.readUInt32LE(),
-				uniqueId: data.readUInt32LE(),
-				position: data.readFloatLE(3),
-				rotation: data.readFloatLE(3),
-				lowerBounds: data.readFloatLE(3),
-				upperBounds: data.readFloatLE(3),
-				flags: data.readUInt16LE(),
-				doodadSet: data.readUInt16LE(),
-				nameSet: data.readUInt16LE(),
-				scale: data.readUInt16LE()
-			};
-		}
-	},
-
-	// MWDS
-	0x4D574453: function(data, chunkSize) {
-		this.doodadSets = data.readUInt16LE(chunkSize / 2);
-	}
-};
-
-module.exports = ADTLoader;
+	};
+	
+	module.exports = ADTLoader;


### PR DESCRIPTION
I used to read the byte[9] array, but essentially this is a ulong value, so you need to do .floor() and get a ulong mask

some render

![image](https://github.com/Kruithne/wow.export/assets/72083834/48c0766b-c903-4a05-91d8-cbefe685e40c)
