### PR TITLE
Clear WMO cache after exporting

### DIFF
--- a/src/js/3D/exporters/ADTExporter.js
+++ b/src/js/3D/exporters/ADTExporter.js
@@ -1168,6 +1168,8 @@ class ADTExporter {
 							log.write('Error: %s', e);
 						}
 					}
+
+					WMOExporter.clearCache();
 				}
 
 				await csv.write();

--- a/src/js/ui/tab-maps.js
+++ b/src/js/ui/tab-maps.js
@@ -203,6 +203,8 @@ const exportSelectedMapWMO = async () => {
 		helper.mark('world model', false, e.message, e.stack);
 	}
 
+	WMOExporter.clearCache();
+
 	helper.finish();
 };
 

--- a/src/js/ui/tab-models.js
+++ b/src/js/ui/tab-models.js
@@ -401,6 +401,8 @@ const exportFiles = async (files, isLocal = false, exportID = -1) => {
 							exporter = new WMOExporter(data, fileDataID);
 
 						await exporter.exportRaw(exportPath, helper, fileManifest);
+						if (fileType === MODEL_TYPE_WMO)
+							WMOExporter.clearCache();
 						break;
 					}
 					case 'OBJ':


### PR DESCRIPTION
The WMO cache needs to be cleared after exporting, otherwise some items will be missing when deleting the previously exported files and exporting again.