### PR TITLE
Add scroll speed setting

### DIFF
--- a/src/default_config.jsonc
+++ b/src/default_config.jsonc
@@ -6,6 +6,7 @@
 //      Linux: ~/.config/<name>/wow.export
 {
 	"listfileURL": "https://github.com/wowdev/wow-listfile/releases/latest/download/community-listfile.csv",
+	"scrollSpeed": 0,
 	"listfileFallbackURL": "https://www.kruithne.net/wow.export/data/listfile/master?v=%s",
 	"listfileCacheRefresh": 3,
 	"listfileSortByID": false,

--- a/src/index.html
+++ b/src/index.html
@@ -76,6 +76,11 @@
 						<file-field v-model="configEdit.exportDirectory" :class="{ concern: isEditExportPathConcerning }"></file-field>
 					</div>
 					<div>
+						<h1>Scroll Speed</h1>
+						<p>How many lines at a time you scroll down in the results view (leave at 0 for default scroll amount)</p>
+						<input type="number" v-model.number="configEdit.scrollSpeed"/>
+					</div>
+					<div>
 						<h1>Show File Data IDs</h1>
 						<p>If enabled, all capable listfiles will have entries suffixed with their fileDataID.</p>
 						<label class="ui-checkbox">

--- a/src/js/components/listbox.js
+++ b/src/js/components/listbox.js
@@ -5,6 +5,7 @@
  */
 
 const path = require('path');
+const core = require('../core');
 
 const fid_filter = (e) => {
 	const start = e.indexOf(' [');
@@ -240,7 +241,7 @@ Vue.component('listbox', {
 			const child = this.$refs.root.querySelector('.item');
 
 			if (child !== null) {
-				const scrollCount = Math.floor(this.$refs.root.clientHeight / child.clientHeight);
+				const scrollCount = core.view.config.scrollSpeed === 0 ? Math.floor(this.$refs.root.clientHeight / child.clientHeight) : core.view.config.scrollSpeed;
 				const direction = e.deltaY > 0 ? 1 : -1;
 				this.scroll += ((scrollCount * this.itemWeight) * weight) * direction;
 				this.recalculateBounds();

--- a/src/js/components/listbox.js
+++ b/src/js/components/listbox.js
@@ -241,7 +241,9 @@ Vue.component('listbox', {
 			const child = this.$refs.root.querySelector('.item');
 
 			if (child !== null) {
-				const scrollCount = core.view.config.scrollSpeed === 0 ? Math.floor(this.$refs.root.clientHeight / child.clientHeight) : core.view.config.scrollSpeed;
+				const scrollCount = core.view.config.scrollSpeed === 0 ?  
+					Math.floor(this.$refs.root.clientHeight / child.clientHeight) : 
+					core.view.config.scrollSpeed;
 				const direction = e.deltaY > 0 ? 1 : -1;
 				this.scroll += ((scrollCount * this.itemWeight) * weight) * direction;
 				this.recalculateBounds();


### PR DESCRIPTION
Requesting to resolve #434
Adding scroll speed setting to options. The default of 0 retains the original scroll amount.

* [`src/default_config.jsonc`](diffhunk://#diff-24d60ea51e0d3a7637cc05973023c2fd009624985e42776d6d14f02a01ef01e0R9): Added a new configuration option `scrollSpeed` with a default value of 0.
* [`src/index.html`](diffhunk://#diff-ce434ef5cc161194b450135a3586eb89357fc270e8aaa8e336db5a04e8d52fbeR78-R82): Added a new section in the settings to allow setting the scroll speed through a number input.
* [`src/js/components/listbox.js`](diffhunk://#diff-b4554335aaec3ddc48a486afa83e8f0b65bdd55f0d494db1170987ce5d6346d1R8): Imported `core` to access the new `scrollSpeed` option.
* [`src/js/components/listbox.js`](diffhunk://#diff-b4554335aaec3ddc48a486afa83e8f0b65bdd55f0d494db1170987ce5d6346d1L243-R244): Modified to use the new `scrollAmount` setting if its not zero.