### PR TITLE
Add ability to export GLTF models without "_p" prefix bones

### DIFF
--- a/src/default_config.jsonc
+++ b/src/default_config.jsonc
@@ -61,6 +61,7 @@
 	"modelsExportTextures": true,
 	"modelsExportAlpha": true,
 	"modelsExportAnimations": false,
+	"modelsExportWithBonePrefix": true,
 	"soundPlayerVolume": 0.7,
 	"soundPlayerAutoPlay": true,
 	"soundPlayerLoop": false,

--- a/src/index.html
+++ b/src/index.html
@@ -699,6 +699,10 @@
 								<input type="checkbox" v-model="config.modelsExportAnimations"/>
 								<span>Export animations</span>
 							</label>
+							<label class="ui-checkbox" title="Include _p Bone Prefixes in Armature for backwards compatibility with previous model exports">
+								<input type="checkbox" v-model="config.modelsExportWithBonePrefix"/>
+								<span>Include Bone Prefixes</span>
+							</label>
 							<label class="ui-checkbox" title="Include Base Clothing">
 								<input type="checkbox" v-model="config.chrIncludeBaseClothing"/>
 								<span>Include base clothing</span>

--- a/src/index.html
+++ b/src/index.html
@@ -109,6 +109,15 @@
 						</label>
 					</div>
 					<div>
+						<h1>Include Bone Prefixes</h1>
+						<p>If enabled, wow.export will Include _p Bone prefixes in model skeleton/armature.</p>
+						<p>Disabling this will break backwards compatibility with previous glTF model and animation exports.</p>
+						<label class="ui-checkbox" title="">
+							<input type="checkbox" v-model="configEdit.modelsExportWithBonePrefix"/>
+							<span>Enable</span>
+						</label>
+					</div>
+					<div>
 						<h1>Enable Shared Textures (Recommended)</h1>
 						<p>If enabled, exported textures will be exported to their own path rather than with their parent.</p>
 						<p>This dramatically reduces disk space used by not duplicating textures.</p>
@@ -698,10 +707,6 @@
 							<label class="ui-checkbox" title="Include Animations in Export">
 								<input type="checkbox" v-model="config.modelsExportAnimations"/>
 								<span>Export animations</span>
-							</label>
-							<label class="ui-checkbox" title="Include _p Bone Prefixes in Armature for backwards compatibility with previous model exports">
-								<input type="checkbox" v-model="config.modelsExportWithBonePrefix"/>
-								<span>Include Bone Prefixes</span>
 							</label>
 							<label class="ui-checkbox" title="Include Base Clothing">
 								<input type="checkbox" v-model="config.chrIncludeBaseClothing"/>

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -412,22 +412,26 @@ class GLTFWriter {
 				}
 
 				const bone_name = BoneMapper.get_bone_name(bone.boneID, bi, bone.boneNameCRC);
-				const prefix_node = {
-					name: bone_name + '_p',
-					translation: bone.pivot.map((v, i) => v - parent_pos[i]),
-					children: [nodeIndex + 1]
+				// rename prefix_node to node
+				const node = {
+					name: bone_name,
+					translation: bone.pivot.map((v, i) => v - parent_pos[i])
+					// No more prefixes so we don't need this
+					//children: [nodeIndex + 1]
 				};
-	
-				const node = { name: bone_name };
+				// We renamed prefix_node to node so redundant
+				//const node = { name: bone_name };
 	
 				bone_lookup_map.set(bi, node);
-	
-				nodes.push(prefix_node);
+				// We renamed the prefix node so comment this out
+				//nodes.push(prefix_node);
 				nodes.push(node);
 	
 				this.inverseBindMatrices.push(...vec3_to_mat4x4(bone.pivot));
-	
-				skin.joints.push(nodeIndex + 1);
+
+				//Don't do +1 if we remove the prefix nodes
+				//https://github.com/Kruithne/wow.export/commit/7a19dcb60ff20b5ca1e2b2f83b6c10ae0afcf5a2#diff-e1681bb244fd61a8a3840e513733c6d99e50b715768f2971a87200d2abd86152L291-L304
+				skin.joints.push(nodeIndex);
 				
 				// Skip rest of the bone logic if we're not exporting animations.
 				if (!core.view.config.modelsExportAnimations)

--- a/src/js/3D/writers/GLTFWriter.js
+++ b/src/js/3D/writers/GLTFWriter.js
@@ -412,26 +412,40 @@ class GLTFWriter {
 				}
 
 				const bone_name = BoneMapper.get_bone_name(bone.boneID, bi, bone.boneNameCRC);
-				// rename prefix_node to node
-				const node = {
-					name: bone_name,
-					translation: bone.pivot.map((v, i) => v - parent_pos[i])
-					// No more prefixes so we don't need this
-					//children: [nodeIndex + 1]
+
+				const prefix_node = {
+					name: bone_name + '_p',
+					translation: bone.pivot.map((v, i) => v - parent_pos[i]),
+					children: [nodeIndex + 1]
 				};
-				// We renamed prefix_node to node so redundant
-				//const node = { name: bone_name };
-	
+
+				// Define how node acts, if we don't use prefixes we need to add position translation
+				const node = core.view.config.modelsExportWithBonePrefix ?
+				{ name: bone_name } :
+				{ name: bone_name, translation: bone.pivot.map((v, i) => v - parent_pos[i])};
+				
 				bone_lookup_map.set(bi, node);
-				// We renamed the prefix node so comment this out
-				//nodes.push(prefix_node);
-				nodes.push(node);
-	
+
+				if (core.view.config.modelsExportWithBonePrefix){
+					nodes.push(prefix_node);
+					nodes.push(node);
+				}
+				else{
+					nodes.push(node);
+				}
+
 				this.inverseBindMatrices.push(...vec3_to_mat4x4(bone.pivot));
 
-				//Don't do +1 if we remove the prefix nodes
-				//https://github.com/Kruithne/wow.export/commit/7a19dcb60ff20b5ca1e2b2f83b6c10ae0afcf5a2#diff-e1681bb244fd61a8a3840e513733c6d99e50b715768f2971a87200d2abd86152L291-L304
-				skin.joints.push(nodeIndex);
+				// We need to wrap this in ifelse or we will create race condition due to the node push above (what)
+				if (core.view.config.modelsExportWithBonePrefix){
+					skin.joints.push(nodeIndex + 1);
+				}
+				else{
+					//Don't do +1 if we remove the prefix nodes
+					//https://github.com/Kruithne/wow.export/commit/7a19dcb60ff20b5ca1e2b2f83b6c10ae0afcf5a2#diff-e1681bb244fd61a8a3840e513733c6d99e50b715768f2971a87200d2abd86152L291-L304
+					skin.joints.push(nodeIndex);
+				}
+
 				
 				// Skip rest of the bone logic if we're not exporting animations.
 				if (!core.view.config.modelsExportAnimations)


### PR DESCRIPTION
There have been a bunch of complaints about the prefix bones being added to the armature on the wow.dev Discord, this makes it so a user can choose to export with (to ensure backwards compatibility) or without the bone prefix nodes.

As per Discord discussion, the default behavior is to have the prefix bones being toggled on by default.

![nw_2025-07-06_20-43-32](https://github.com/user-attachments/assets/96b2beb8-8b09-447d-bc68-c8ebbb1c48be)

With include bone prefixes toggled on
![blender_2025-07-06_22-31-11](https://github.com/user-attachments/assets/3fe6ed44-249f-4f3b-9f99-40533cadc6bb)

With include bone prefixes toggled off
![blender_2025-07-06_22-33-52](https://github.com/user-attachments/assets/81b0086c-da3f-40d7-98ed-b80bd38de47a)


