### PR TITLE
Disable nwjs trying to use OS keychain storage that results in unneccessary prompts on launch 

### DIFF
--- a/build.json
+++ b/build.json
@@ -7,7 +7,7 @@
 	"manifest": {
 		"name": "wow.export",
 		"main": "./src/index.html",
-		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging",
+		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging --password-store=basic",
 		"product_string": "wow.export",
 		"user-agent": "wow.export (%ver); %osinfo",
 		"window": {


### PR DESCRIPTION
I have noticed that wow.export on Linux is trying to reach out to the keyring manager with each launch 
If it's disabled it'll generate errors, if not disabled it'll create a pop-up asking for the system keyring unlock
```[9879:9879:0901/112654.195955:ERROR:kwallet_dbus.cc(100)] Error contacting kwalletd (isEnabled)
[9879:9879:0901/112654.196059:ERROR:object_proxy.cc(623)] Failed to call method: org.kde.KLauncher.start_service_by_desktop_name: object_path= /KLauncher: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
[9879:9879:0901/112654.196067:ERROR:kwallet_dbus.cc(72)] Error contacting klauncher to start kwalletd
[9879:9879:0901/112654.196181:ERROR:kwallet_dbus.cc(418)] Error contacting kwalletd (close)
```
This should be switched to basic as there's no credentials being used
https://github.com/nwjs/chromium.src/blob/nw13/chrome/common/chrome_switches.cc#L1152

It's very common for this to be omitted as is in this example:
https://steamcommunity.com/app/368340/discussions/1/1742230617617824267/