### PR TITLE
Blender Addon: Fix ADT placement import resilience and add per-tile diagnostics

### DIFF
--- a/addons/blender/io_scene_wowobj/__init__.py
+++ b/addons/blender/io_scene_wowobj/__init__.py
@@ -128,6 +128,7 @@ class ImportWoWOBJ(bpy.types.Operator, ImportHelper):
             importLiquid = self.importLiquid,
             importUVAnimations = self.importUVAnimations
         )
+        settings._import_cache_cleared = False
 
         from . import import_wowobj
         if self.files:


### PR DESCRIPTION
Hi Kruithne! I'm working on a Game/YouTube video with WoW assets and I had an issue with the Blender add-on where certain tiles were not correctly importing doodads.

In my case, the placement CSVs for adt_35_30.obj through adt_35_34.obj (tiles from Kalimdor / The Barrens) were present and populated (hundreds of rows), but the import could still end up with missing/empty results because the placement import loop was effectively “all-or-nothing” per tile: a single bad/missing model reference (or other per-row exception) could abort the remainder of the CSV processing, so a tile could appear to get no doodads even though the CSV had valid entries.

This PR makes the placement import more robust by handling placement rows defensively (skip/log failures per row and continue), adds a per-tile import summary to the console, and clears the importedModelIDs cache once per import run to avoid unintended duplicate-suppression across repeated imports in the same .blend.

Tiles used to reproduce/validate:

adt_35_30.obj
adt_35_31.obj
adt_35_32.obj
adt_35_33.obj
adt_35_34.obj