### PR TITLE
m2 rendering improvements

### DIFF
--- a/src/js/3D/ShaderMapper.js
+++ b/src/js/3D/ShaderMapper.js
@@ -42,7 +42,7 @@ const SHADER_ARRAY = [
 	{ "PS": "Combiners_Opaque",                         "VS": "Diffuse_T1",             "HS": "T1",       "DS": "T1"        },
 	{ "PS": "Combiners_Mod_Mod2x",                      "VS": "Diffuse_EdgeFade_T1_T2", "HS": "T1_T2",    "DS": "T1_T2"     },
 	{ "PS": "Combiners_Mod",                            "VS": "Diffuse_EdgeFade_T1",    "HS": "T1_T2",    "DS": "T1_T2"     },
-	{ "PS": "Combiners_Mod_Mod",                        "VS": "Diffuse_EdgeFade_T1_T2", "HS": "T1_T2",    "DS": "T1_T2"     },
+	{ "PS": "Combiners_Mod_Mod_Depth",                  "VS": "Diffuse_EdgeFade_T1_T2", "HS": "T1_T2",    "DS": "T1_T2"     },
 ];
 
 
@@ -50,7 +50,7 @@ const SHADER_ARRAY = [
  * Gets Vertex shader name from shader ID
  */
 const getVertexShader = (textureCount, shaderID) => {
-	if (shaderID < 0) {
+	if (shaderID & 0x8000) {
 		const vertexShaderId = shaderID & 0x7FFF;
 		if (vertexShaderId >= SHADER_ARRAY.length) {
 			log.write("Unknown vertex shader ID: " + vertexShaderId);

--- a/src/js/3D/Skin.js
+++ b/src/js/3D/Skin.js
@@ -78,7 +78,7 @@ class Skin {
 			for (let i = 0; i < textureUnitsCount; i++) {
 				this.textureUnits[i] = {
 					flags: data.readUInt8(),
-					priority: data.readUInt8(),
+					priority: data.readInt8(),
 					shaderID: data.readUInt16LE(),
 					skinSectionIndex: data.readUInt16LE(),
 					flags2: data.readUInt16LE(),

--- a/src/js/3D/gl/GLContext.js
+++ b/src/js/3D/gl/GLContext.js
@@ -263,14 +263,19 @@ class GLContext {
 
 			case BlendMode.ALPHA:
 				this.set_blend(true);
-				this.set_blend_func(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+				this.set_blend_func_separate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 				this.set_depth_write(false);
 				break;
 
 			case BlendMode.ADD:
+				this.set_blend(true);
+				this.set_blend_func_separate(gl.SRC_ALPHA, gl.ONE, gl.ZERO, gl.ONE);
+				this.set_depth_write(false);
+				break;
+
 			case BlendMode.NO_ALPHA_ADD:
 				this.set_blend(true);
-				this.set_blend_func(gl.SRC_ALPHA, gl.ONE);
+				this.set_blend_func_separate(gl.ONE, gl.ONE, gl.ZERO, gl.ONE);
 				this.set_depth_write(false);
 				break;
 

--- a/src/js/3D/gl/ShaderProgram.js
+++ b/src/js/3D/gl/ShaderProgram.js
@@ -116,6 +116,27 @@ class ShaderProgram {
 
 	/**
 	 * @param {string} name
+	 * @param {GLenum} pname
+	 * @returns {any|null}
+	 */
+	get_uniform_block_param(name, pname) {
+		const index = this.get_uniform_block_index(name);
+		if (index !== this.gl.INVALID_INDEX)
+			return this.gl.getActiveUniformBlockParameter (this.program, name, pname);
+		return null;
+	}
+
+	/**
+	 * @param {string[]} names
+	 * @param {number[]|null} offsets
+	 */
+	get_active_uniform_offsets(names) {
+		const indices = this.gl.getUniformIndices(this.program, names);
+		return this.gl.getActiveUniforms(this.program, indices, this.gl.UNIFORM_OFFSET);
+	}
+
+	/**
+	 * @param {string} name
 	 * @param {number} binding_point
 	 */
 	bind_uniform_block(name, binding_point) {

--- a/src/js/3D/gl/UniformBuffer.js
+++ b/src/js/3D/gl/UniformBuffer.js
@@ -174,6 +174,17 @@ class UniformBuffer {
 	}
 
 	/**
+	 * get float32view of binding buffer, will need to be manually uploaded with
+	 * upload_range as dirty tracking will be missing
+	 * @param {number} offset - byte offset
+	 * @param {number} length - length of view
+	 * @param {Float32Array} view
+	 */
+	get_float32_view(offset, length) {
+		return new Float32Array(this.data, offset, length);
+	}
+
+	/**
 	 * Upload data to GPU if dirty
 	 */
 	upload() {

--- a/src/js/3D/gl/VertexArray.js
+++ b/src/js/3D/gl/VertexArray.js
@@ -111,12 +111,12 @@ class VertexArray {
 
 	/**
 	 * Set up M2 vertex format
-	 * layout: position(3f) + normal(3f) + bone_indices(4ub) + bone_weights(4ub) + uv1(2f)
-	 * stride = 40 bytes
+	 * layout: position(3f) + normal(3f) + bone_indices(4ub) + bone_weights(4ub) + uv1(2f) + uv2(2f)
+	 * stride = 48 bytes
 	 */
 	setup_m2_vertex_format() {
 		const gl = this.gl;
-		const stride = 40;
+		const stride = 48;
 
 		this.bind();
 		gl.bindBuffer(gl.ARRAY_BUFFER, this.vbo);
@@ -141,7 +141,9 @@ class VertexArray {
 		gl.enableVertexAttribArray(AttributeLocation.TEXCOORD);
 		gl.vertexAttribPointer(AttributeLocation.TEXCOORD, 2, gl.FLOAT, false, stride, 32);
 
-		// texcoord2 uses separate buffer or not present for simple models
+		// texcoord2: vec2 at offset 40
+		gl.enableVertexAttribArray(AttributeLocation.TEXCOORD2);
+		gl.vertexAttribPointer(AttributeLocation.TEXCOORD2, 2, gl.FLOAT, false, stride, 40);
 	}
 
 	/**

--- a/src/js/3D/loaders/M2Loader.js
+++ b/src/js/3D/loaders/M2Loader.js
@@ -880,7 +880,7 @@ class M2Loader {
 		const base = this.data.offset;
 		this.data.seek(globalLoopOfs + ofs);
 
-		this.globalLoops = this.data.readInt16LE(globalLoopCount);
+		this.globalLoops = this.data.readInt32LE(globalLoopCount);
 
 		this.data.seek(base);
 	}

--- a/src/js/3D/loaders/SKELLoader.js
+++ b/src/js/3D/loaders/SKELLoader.js
@@ -174,7 +174,7 @@ class SKELLoader {
 		let prevPos = this.data.offset;
 		this.data.seek(globalLoopOfs + chunk_ofs);
 
-		this.globalLoops = this.data.readInt16LE(globalLoopCount);
+		this.globalLoops = this.data.readInt32LE(globalLoopCount);
 
 		this.data.seek(prevPos);
 

--- a/src/js/3D/renderers/M2LegacyRendererGL.js
+++ b/src/js/3D/renderers/M2LegacyRendererGL.js
@@ -932,10 +932,8 @@ class M2LegacyRendererGL {
 		// bone skinning disabled for legacy models until animation system is fixed
 		shader.set_uniform_1i('u_bone_count', 0);
 
-		shader.set_uniform_1i('u_has_tex_matrix1', 0);
-		shader.set_uniform_1i('u_has_tex_matrix2', 0);
-		shader.set_uniform_mat4('u_tex_matrix1', false, IDENTITY_MAT4);
-		shader.set_uniform_mat4('u_tex_matrix2', false, IDENTITY_MAT4);
+		shader.set_uniform_1i('u_tex_matrix1_idx', -1);
+		shader.set_uniform_1i('u_tex_matrix2_idx', -1);
 
 		const lx = 3, ly = -0.7, lz = -2;
 		const light_view_x = view_matrix[0] * lx + view_matrix[4] * ly + view_matrix[8] * lz;

--- a/src/js/3D/renderers/M2LegacyRendererGL.js
+++ b/src/js/3D/renderers/M2LegacyRendererGL.js
@@ -301,9 +301,9 @@ class M2LegacyRendererGL {
 		this._create_skeleton();
 
 		// build interleaved vertex buffer
-		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) = 40 bytes
+		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) + uv(2f) = 48 bytes
 		const vertex_count = m2.vertices.length / 3;
-		const stride = 40;
+		const stride = 48;
 		const vertex_data = new ArrayBuffer(vertex_count * stride);
 		const vertex_view = new DataView(vertex_data);
 
@@ -338,6 +338,10 @@ class M2LegacyRendererGL {
 			// texcoord
 			vertex_view.setFloat32(offset + 32, m2.uv[uv_idx], true);
 			vertex_view.setFloat32(offset + 36, m2.uv[uv_idx + 1], true);
+
+			// texcoord2
+			vertex_view.setFloat32(offset + 40, m2.uv2[uv_idx], true);
+			vertex_view.setFloat32(offset + 44, m2.uv2[uv_idx + 1], true);
 		}
 
 		// map triangle indices

--- a/src/js/3D/renderers/M2LegacyRendererGL.js
+++ b/src/js/3D/renderers/M2LegacyRendererGL.js
@@ -16,6 +16,7 @@ const VertexArray = require('../gl/VertexArray');
 const GLTexture = require('../gl/GLTexture');
 
 const textureRibbon = require('../../ui/texture-ribbon');
+const UniformBuffer = require('../gl/UniformBuffer');
 
 // m2 version constants
 const M2_VER_WOTLK = 264;
@@ -150,6 +151,7 @@ class M2LegacyRendererGL {
 
 		// rendering state
 		this.vaos = [];
+		this.ubos = [];
 		this.textures = new Map();
 		this.default_texture = null;
 		this.buffers = [];
@@ -368,6 +370,8 @@ class M2LegacyRendererGL {
 		vao.setup_m2_vertex_format();
 		this.vaos.push(vao);
 
+		this._create_bones_ubo();
+
 		if (this.reactive)
 			this.geosetArray = new Array(skin.subMeshes.length);
 
@@ -445,15 +449,29 @@ class M2LegacyRendererGL {
 
 		if (!bone_data || bone_data.length === 0) {
 			this.bones = null;
-			this.bone_matrices = new Float32Array(16);
 			return;
 		}
 
 		this.bones = bone_data;
-		this.bone_matrices = new Float32Array(bone_data.length * 16);
+	}
 
-		for (let i = 0; i < bone_data.length; i++)
-			this.bone_matrices.set(IDENTITY_MAT4, i * 16);
+	_create_bones_ubo() {
+		this.shader.bind_uniform_block("VsBoneUbo", 0);
+		const ubosize = this.shader.get_uniform_block_param("VsBoneUbo", this.gl.UNIFORM_BLOCK_DATA_SIZE);
+		const offsets = this.shader.get_active_uniform_offsets(["u_bone_matrices"]);
+		const ubo = new UniformBuffer(this.ctx, ubosize);
+		this.ubos.push({
+			ubo: ubo,
+			offsets: offsets
+		});
+
+		this.bone_matrices = ubo.get_float32_view(offsets[0], (ubosize - offsets[0]) / 4);
+		const bone_count = Math.min(this.bones ? this.bones.length : 0, this.bone_matrices.length / 16);
+		// initialize to identity
+		for (let i = 0; i < bone_count; i++) {
+			const offset = i * 16;
+			this.bone_matrices.set(IDENTITY_MAT4, offset);
+		}
 	}
 
 	async playAnimation(index) {
@@ -932,8 +950,8 @@ class M2LegacyRendererGL {
 		// bone skinning disabled for legacy models until animation system is fixed
 		shader.set_uniform_1i('u_bone_count', 0);
 
-		shader.set_uniform_1i('u_tex_matrix1_idx', -1);
-		shader.set_uniform_1i('u_tex_matrix2_idx', -1);
+		shader.set_uniform_mat4('u_tex_matrix1', false, IDENTITY_MAT4);
+		shader.set_uniform_mat4('u_tex_matrix2', false, IDENTITY_MAT4);
 
 		const lx = 3, ly = -0.7, lz = -2;
 		const light_view_x = view_matrix[0] * lx + view_matrix[4] * ly + view_matrix[8] * lz;
@@ -996,6 +1014,7 @@ class M2LegacyRendererGL {
 				texture.bind(t);
 			}
 
+			this.ubos[0].ubo.bind(0);
 			dc.vao.bind();
 			gl.drawElements(
 				wireframe ? gl.LINES : gl.TRIANGLES,
@@ -1027,7 +1046,10 @@ class M2LegacyRendererGL {
 	_dispose_skin() {
 		for (const vao of this.vaos)
 			vao.dispose();
+		for (const ubo of this.ubos)
+			ubo.ubo.dispose();
 
+		this.ubos = [];
 		this.vaos = [];
 		this.buffers = [];
 		this.draw_calls = [];

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -449,9 +449,9 @@ class M2RendererGL {
 		await this._create_skeleton();
 
 		// build interleaved vertex buffer
-		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) = 40 bytes
+		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) + uv(2f) = 48 bytes
 		const vertex_count = m2.vertices.length / 3;
-		const stride = 40;
+		const stride = 48;
 		const vertex_data = new ArrayBuffer(vertex_count * stride);
 		const vertex_view = new DataView(vertex_data);
 
@@ -486,6 +486,10 @@ class M2RendererGL {
 			// texcoord
 			vertex_view.setFloat32(offset + 32, m2.uv[uv_idx], true);
 			vertex_view.setFloat32(offset + 36, m2.uv[uv_idx + 1], true);
+
+			// texcoord2
+			vertex_view.setFloat32(offset + 40, m2.uv2[uv_idx], true);
+			vertex_view.setFloat32(offset + 44, 1 - m2.uv2[uv_idx + 1], true);
 		}
 
 		// map triangle indices

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -541,9 +541,13 @@ class M2RendererGL {
 			let flags = 0;
 			let texture_count = 1;
 			let tex_mtx_idxs = [-1, -1];
+			let prio = 0;
+			let layer = 0;
 
 			if (tex_unit) {
 				texture_count = tex_unit.textureCount;
+				prio = tex_unit.priority;
+				layer = tex_unit.materialLayer;
 
 				// get all texture indices for multi-texture shaders
 				for (let j = 0; j < Math.min(texture_count, 4); j++) {
@@ -582,6 +586,8 @@ class M2RendererGL {
 				flags: flags,
 				visible: true,
 				tex_matrix_idxs: tex_mtx_idxs,
+				prio: prio,
+				layer: layer,
 			};
 
 			this.draw_calls.push(draw_call);
@@ -1288,12 +1294,13 @@ class M2RendererGL {
 		// default texture weights
 		shader.set_uniform_3f('u_tex_sample_alpha', 1, 1, 1);
 
-		// sort draw calls by blend mode (opaque first, then transparent)
 		const sorted_calls = [...this.draw_calls].sort((a, b) => {
-			const a_opaque = a.blend_mode === 0 || a.blend_mode === 1;
-			const b_opaque = b.blend_mode === 0 || b.blend_mode === 1;
-			if (a_opaque !== b_opaque)
-				return a_opaque ? -1 : 1;
+			if (a.prio != b.prio)
+				return a.prio - b.prio;
+			if (a.layer != b.layer)
+				return a.layer - b.layer;
+			if (a.blend_mode != b.blend_mode)
+				return a.blend_mode - b.blend_mode;
 
 			return 0;
 		});

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -84,6 +84,17 @@ const PIXEL_SHADER_IDS = {
 	'Combiners_Mod_Mod_Depth': 36
 };
 
+const M2BLEND_TO_EGX = [
+	GLContext.BlendMode.OPAQUE,
+	GLContext.BlendMode.ALPHA_KEY,
+	GLContext.BlendMode.ALPHA,
+	GLContext.BlendMode.NO_ALPHA_ADD,
+	GLContext.BlendMode.ADD,
+	GLContext.BlendMode.MOD,
+	GLContext.BlendMode.MOD2X,
+	GLContext.BlendMode.BLEND_ADD,
+]
+
 // identity matrix
 const IDENTITY_MAT4 = new Float32Array([
 	1, 0, 0, 0,
@@ -539,7 +550,10 @@ class M2RendererGL {
 
 				const mat = m2.materials[tex_unit.materialIndex];
 				if (mat) {
-					blend_mode = mat.blendingMode;
+					if (M2BLEND_TO_EGX.length > mat.blendingMode)
+						blend_mode = M2BLEND_TO_EGX[mat.blendingMode];
+					else
+						blend_mode = mat.blendingMode;
 					flags = mat.flags;
 
 					this.material_props.set(tex_indices[0], { blendMode: blend_mode, flags: flags });
@@ -1300,6 +1314,11 @@ class M2RendererGL {
 				ctx.set_depth_test(false);
 			else
 				ctx.set_depth_test(true);
+
+			if (dc.flags & 0x10)
+				ctx.set_depth_write(false);
+			else
+				ctx.set_depth_write(true);
 
 			// bind textures (up to 4 for multi-texture shaders)
 			for (let t = 0; t < 4; t++) {

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -339,6 +339,7 @@ class M2RendererGL {
 		this.animation_time = 0;
 		this.animation_paused = false;
 		this.tex_matrices = null;
+		this.submesh_colors = new Float32Array();
 
 		// global sequences
 		this.global_seq_times = new Float32Array();
@@ -391,6 +392,7 @@ class M2RendererGL {
 		// load textures
 		await this._load_textures();
 		this.global_seq_times = new Float32Array(this.m2.globalLoops.length);
+		this.submesh_colors = new Float32Array(this.m2.colors.length * 4);
 
 		// load first skin
 		if (this.m2.vertices.length > 0) {
@@ -549,11 +551,14 @@ class M2RendererGL {
 			let tex_mtx_idxs = [-1, -1];
 			let prio = 0;
 			let layer = 0;
+			let coloridx = -1;
 
 			if (tex_unit) {
 				texture_count = tex_unit.textureCount;
 				prio = tex_unit.priority;
 				layer = tex_unit.materialLayer;
+				if (tex_unit.colorIndex < m2.colors.length)
+					coloridx = tex_unit.colorIndex;
 
 				// get all texture indices for multi-texture shaders
 				for (let j = 0; j < Math.min(texture_count, 4); j++) {
@@ -605,6 +610,7 @@ class M2RendererGL {
 				tex_matrix_idxs: tex_mtx_idxs,
 				prio: prio,
 				layer: layer,
+				color_idx: coloridx,
 			};
 
 			this.draw_calls.push(draw_call);
@@ -771,6 +777,7 @@ class M2RendererGL {
 		this.animation_time = 0;
 		this.animation_paused = false;
 		this.global_seq_times.fill(0);
+		this.submesh_colors.fill(1);
 
 		// calculate bone matrices using animation 0 (stand) at time 0 for rest pose
 		if (this.bones) {
@@ -783,6 +790,7 @@ class M2RendererGL {
 			this.current_anim_source = this.skelLoader || this.m2;
 			this._update_bone_matrices();
 			this._update_tex_matrices();
+			this._update_submesh_colors();
 
 			this.current_animation = null;
 			this.current_anim_index = null;
@@ -823,6 +831,7 @@ class M2RendererGL {
 		// update bone matrices
 		this._update_bone_matrices();
 		this._update_tex_matrices();
+		this._update_submesh_colors();
 	}
 
 	get_animation_duration() {
@@ -858,6 +867,7 @@ class M2RendererGL {
 		this.animation_time = (frame / frame_count) * duration;
 		this._update_bone_matrices();
 		this._update_tex_matrices();
+		this._update_submesh_colors();
 	}
 
 	set_animation_paused(paused) {
@@ -1135,6 +1145,37 @@ class M2RendererGL {
 
 			const offset = i * 16;
 			tm.set(local_mat, offset);
+		}
+	}
+
+	_update_submesh_colors() {
+		const anim_source = this.current_anim_source || this.skelLoader || this.m2;
+		const anim_idx = this.current_anim_index ?? this.current_animation;
+		const anim = anim_source.animations?.[anim_idx];
+		if (!anim)
+			return;
+
+		const m2 = this.m2;
+
+		for (let i = 0; i < m2.colors.length; ++i) {
+			let rgb = this._animate_track(anim, m2.colors[i].color, [1, 1, 1], (a,b,c) => {
+					return [
+						lerp(a[0], b[0], c),
+						lerp(a[1], b[1], c),
+						lerp(a[2], b[2], c),
+						lerp(a[3], b[3], c),
+					]
+			});
+
+			this.submesh_colors[(i*4)+0] = rgb[0];
+			this.submesh_colors[(i*4)+1] = rgb[1];
+			this.submesh_colors[(i*4)+2] = rgb[2];
+
+			let a = this._animate_track(anim, m2.colors[i].alpha, 32767, (a, b, c) => {
+				return lerp(a, b, c);
+			});
+
+			this.submesh_colors[(i*4) + 3] = a / 32768;
 		}
 	}
 
@@ -1502,7 +1543,12 @@ class M2RendererGL {
 			shader.set_uniform_mat4('u_tex_matrix2', false, tmi1 == -1 ? IDENTITY_MAT4 : get_tex_matrix(tmi1));
 
 			// mesh color (white for now)
-			shader.set_uniform_4f('u_mesh_color', 1, 1, 1, 1);
+			let color = [1,1,1,1];
+			if (dc.color_idx != -1) {
+				color = this.submesh_colors.subarray(dc.color_idx * 4, (dc.color_idx * 4) + 4);
+			}
+			shader.set_uniform_4f('u_mesh_color', color[0], color[1], color[2], color[3]);
+
 			shader.set_uniform_1i('u_apply_lighting', dc.flags & 0x1 ? 0 : 1);
 
 			// apply blend mode

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -399,6 +399,8 @@ class M2RendererGL {
 			}
 		}
 
+		this._create_tex_matrices();
+
 		// drop reference to raw data
 		this.data = undefined;
 	}
@@ -572,6 +574,17 @@ class M2RendererGL {
 
 					this.material_props.set(tex_indices[0], { blendMode: blend_mode, flags: flags });
 				}
+
+				if (tex_unit.textureTransformComboIndex < m2.textureTransformsLookup.length) {
+					const idx = m2.textureTransformsLookup[tex_unit.textureTransformComboIndex];
+					if (idx < m2.textureTransforms.length)
+						tex_mtx_idxs[0] = idx;
+				}
+				if (tex_unit.textureTransformComboIndex + 1 < m2.textureTransformsLookup.length) {
+					const idx = m2.textureTransformsLookup[tex_unit.textureTransformComboIndex + 1];
+					if (idx < m2.textureTransforms.length)
+						tex_mtx_idxs[1] = idx;
+				}
 			}
 
 			const draw_call = {
@@ -684,6 +697,21 @@ class M2RendererGL {
 		}
 	}
 
+	_create_tex_matrices() {
+		const m2 = this.m2;
+		const tt = m2.textureTransforms;
+
+		if (tt.length <= 0) {
+			return;
+		}
+
+		this.tex_matrices = new Float32Array(tt.length * 16);
+		for (let i = 0; i < tt.length; i++) {
+			const offset = i * 16;
+			this.tex_matrices.set(IDENTITY_MAT4, offset);
+		}
+	}
+
 	/**
 	 * Play animation by index
 	 * @param {number} index
@@ -738,6 +766,7 @@ class M2RendererGL {
 			this.current_anim_index = 0;
 			this.current_anim_source = this.skelLoader || this.m2;
 			this._update_bone_matrices();
+			this._update_tex_matrices();
 
 			this.current_animation = null;
 			this.current_anim_index = null;
@@ -777,6 +806,7 @@ class M2RendererGL {
 
 		// update bone matrices
 		this._update_bone_matrices();
+		this._update_tex_matrices();
 	}
 
 	get_animation_duration() {
@@ -811,6 +841,7 @@ class M2RendererGL {
 		const duration = this.get_animation_duration();
 		this.animation_time = (frame / frame_count) * duration;
 		this._update_bone_matrices();
+		this._update_tex_matrices();
 	}
 
 	set_animation_paused(paused) {
@@ -960,6 +991,135 @@ class M2RendererGL {
 		// calculate all bones
 		for (let i = 0; i < bone_count; i++)
 			calc_bone(i);
+	}
+
+	_find_time_index(currtime, times) {
+		if (times.length > 1) {
+			if (currtime > times[times.length - 1]) return times.length - 1;
+			let lowerbound = (a, b) => { let n = a.length; for (let i=0;i<n;++i) {if (a[i] >= b) return i;} return n;};
+			let time = lowerbound(times, currtime);
+			if (time != 0) {
+				time--;
+			}
+			return time;
+		} else if (times.length == 1) {
+			return 0;
+		} else return -1;
+	}
+
+	_animate_track(anim, animblock, def, lerpfunc) {
+		const m2 = this.m2;
+		const gl = m2.globalLoops;
+		let at = (this.animation_time * 1000);
+		let ai = this.current_anim_index;
+		let maxtime = anim.duration;
+
+		const gs = animblock.globalSeq;
+		if (gs < this.global_seq_times.length) {
+			at = this.global_seq_times[gs];
+			maxtime = gl[gs];
+		}
+
+		if (animblock.timestamps.length == 0)
+			return def;
+
+		if (animblock.timestamps.length <= ai)
+			ai = 0;
+
+		if (ai <= animblock.timestamps[ai].length && animblock.timestamps[ai].length == 0)
+			return def;
+
+		const times = animblock.timestamps[ai];
+		const values = animblock.values[ai];
+		const intertype = animblock.interpolation;
+
+		let ti = 0;
+		if (maxtime != 0) {
+			ti = this._find_time_index(at, times);
+		}
+		if (ti == times.length-1)
+			return values[ti];
+		else if (ti >= 0) {
+			let v1 = values[ti];
+			let v2 = values[ti + 1];
+			let t1 = times[ti];
+			let t2 = times[ti + 1];
+
+			if (intertype == 0)
+				return v1;
+			else {
+				return lerpfunc(v1, v2, (at - t1) / (t2 -t1));
+			}
+		} else {
+			return values[0];
+		}
+	}
+
+	_update_tex_matrices() {
+		const anim_source = this.current_anim_source || this.skelLoader || this.m2;
+		const anim_idx = this.current_anim_index ?? this.current_animation;
+		const anim = anim_source.animations?.[anim_idx];
+		if (!anim)
+			return;
+
+		const m2 = this.m2;
+		const tm = this.tex_matrices;
+
+		const temp_result = new Float32Array(16);
+
+		for (let i = 0; i < m2.textureTransforms.length; ++i) {
+			const tt = m2.textureTransforms[i];
+			const local_mat = new Float32Array(16);
+			mat4_copy(local_mat, IDENTITY_MAT4);
+
+			const transmat = [0.5, 0.5, 0, 0];
+			const pivotpoint = [-0.5, -0.5, 0, 0];
+
+			if (tt.rotation.values.length) {
+				const [qx, qy, qz, qw] = this._animate_track(anim, tt.rotation, [1,0,0,0], (a,b,c)=>{
+					const out = [0, 0, 0, 1];
+					quat_slerp(out, a[0], a[1], a[2], a[3], b[0], b[1], b[2], b[3], c);
+					return out;
+				});
+				mat4_from_translation(temp_result, transmat[0], transmat[1], transmat[2]);
+				mat4_multiply(local_mat, local_mat, temp_result);
+				mat4_from_quat(temp_result, qx, qy, qz, qw);
+				mat4_multiply(local_mat, local_mat, temp_result);
+				mat4_from_translation(temp_result, pivotpoint[0], pivotpoint[1], pivotpoint[2]);
+				mat4_multiply(local_mat, local_mat, temp_result);
+			}
+			if (tt.scaling.values.length) {
+				const [qx, qy, qz, qw] = this._animate_track(anim, tt.scaling, [1,1,1,1], (a,b,c)=> {
+					return [
+						lerp(a[0], b[0], c),
+						lerp(a[1], b[1], c),
+						lerp(a[2], b[2], c),
+						lerp(a[3], b[3], c),
+					]
+				});
+				mat4_from_translation(temp_result, transmat[0], transmat[1], transmat[2]);
+				mat4_multiply(local_mat, local_mat, temp_result);
+				mat4_from_scale(temp_result, qx, qy, qz);
+				mat4_multiply(local_mat, local_mat, temp_result);
+				mat4_from_translation(temp_result, pivotpoint[0], pivotpoint[1], pivotpoint[2]);
+				mat4_multiply(local_mat, local_mat, temp_result);
+			}
+			if (tt.translation.values.length) {
+				const [qx, qy, qz, qw] = this._animate_track(anim, tt.translation, [0,0,0,0], (a,b,c)=> {
+					return [
+						lerp(a[0], b[0], c),
+						lerp(a[1], b[1], c),
+						lerp(a[2], b[2], c),
+						lerp(a[3], b[3], c),
+					]
+				});
+				mat4_from_translation(temp_result, qx, qy, qz);
+				mat4_multiply(local_mat, local_mat, temp_result);
+			}
+
+			const offset = i * 16;
+			tm.set(local_mat, offset);
+		}
 	}
 
 	_sample_raw_vec3(timestamps, values, time_ms, default_value = [0, 0, 0]) {

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -19,6 +19,7 @@ const VertexArray = require('../gl/VertexArray');
 const GLTexture = require('../gl/GLTexture');
 
 const textureRibbon = require('../../ui/texture-ribbon');
+const UniformBuffer = require('../gl/UniformBuffer');
 
 // vertex shader name to ID mapping (matches vertex shader switch cases)
 const VERTEX_SHADER_IDS = {
@@ -325,6 +326,7 @@ class M2RendererGL {
 
 		// rendering state
 		this.vaos = [];
+		this.ubos = [];
 		this.textures = new Map();
 		this.default_texture = null;
 		this.buffers = [];
@@ -381,6 +383,8 @@ class M2RendererGL {
 		// load shader program
 		this.shader = M2RendererGL.load_shaders(this.ctx);
 
+		this._create_tex_matrices();
+
 		// create default texture
 		this._create_default_texture();
 
@@ -398,8 +402,6 @@ class M2RendererGL {
 				this.bonesWatcher = core.view.$watch('config.modelViewerShowBones', () => {}, { deep: true });
 			}
 		}
-
-		this._create_tex_matrices();
 
 		// drop reference to raw data
 		this.data = undefined;
@@ -524,6 +526,8 @@ class M2RendererGL {
 		vao.setup_m2_vertex_format();
 
 		this.vaos.push(vao);
+
+		this._create_bones_ubo();
 
 		// reactive geoset array
 		if (this.reactive)
@@ -672,18 +676,10 @@ class M2RendererGL {
 
 		if (!bone_data || bone_data.length === 0) {
 			this.bones = null;
-			this.bone_matrices = new Float32Array(16); // single identity
 			return;
 		}
 
 		this.bones = bone_data;
-		this.bone_matrices = new Float32Array(bone_data.length * 16);
-
-		// initialize to identity
-		for (let i = 0; i < bone_data.length; i++) {
-			const offset = i * 16;
-			this.bone_matrices.set(IDENTITY_MAT4, offset);
-		}
 
 		// find HandsClosed animation (ID 15) for hand grip
 		const anim_source = this.skelLoader || this.m2;
@@ -694,6 +690,26 @@ class M2RendererGL {
 					break;
 				}
 			}
+		}
+	}
+
+	_create_bones_ubo() {
+		this.shader.bind_uniform_block("VsBoneUbo", 0);
+		const ubosize = this.shader.get_uniform_block_param("VsBoneUbo", this.gl.UNIFORM_BLOCK_DATA_SIZE);
+		const offsets = this.shader.get_active_uniform_offsets(["u_bone_matrices"]);
+		const ubo = new UniformBuffer(this.ctx, ubosize);
+		this.ubos.push({
+			ubo: ubo,
+			offsets: offsets
+		});
+
+		this.bone_matrices = ubo.get_float32_view(offsets[0], (ubosize - offsets[0]) / 4);
+
+		const bone_count = Math.min(this.bones ? this.bones.length : 0, this.bone_matrices.length / 16);
+		// initialize to identity
+		for (let i = 0; i < bone_count; i++) {
+			const offset = i * 16;
+			this.bone_matrices.set(IDENTITY_MAT4, offset);
 		}
 	}
 
@@ -1422,10 +1438,11 @@ class M2RendererGL {
 		shader.set_uniform_3f('u_view_up', 0, 1, 0);
 		shader.set_uniform_1f('u_time', performance.now() * 0.001);
 
-		// bone matrices
-		shader.set_uniform_1i('u_bone_count', this.bones ? this.bones.length : 0);
-		if (this.bones && this.bone_matrices)
-			shader.set_uniform_mat4('u_bone_matrices', false, this.bone_matrices);
+		const ubo = this.ubos[0];
+		const bone_count = this.bones ? this.bones.length : 0;
+		shader.set_uniform_1i('u_bone_count', bone_count);
+		if (bone_count)
+			ubo.ubo.upload_range(ubo.offsets[0], bone_count * 16 * 4);
 
 		// lighting - transform light direction to view space
 		const lx = 3, ly = -0.7, lz = -2;
@@ -1475,11 +1492,15 @@ class M2RendererGL {
 			shader.set_uniform_1i('u_pixel_shader', dc.pixel_shader);
 			shader.set_uniform_1i('u_blend_mode', dc.blend_mode);
 
-			// texture matrix defaults
-			shader.set_uniform_1i('u_tex_matrix1_idx', dc.tex_matrix_idxs[0]);
-			shader.set_uniform_1i('u_tex_matrix2_idx', dc.tex_matrix_idxs[1]);
-			if (dc.tex_matrix_idxs[0] >= 0 || dc.tex_matrix_idxs[1] >= 0)
-				shader.set_uniform_mat4('u_tex_matrices', false, this.tex_matrices);
+			const tmi0 = dc.tex_matrix_idxs[0];
+			const tmi1 = dc.tex_matrix_idxs[1];
+
+			const get_tex_matrix = (idx) => {
+				return this.tex_matrices.subarray(idx * 16, (idx + 1) * 16);
+			}
+
+			shader.set_uniform_mat4('u_tex_matrix1', false, tmi0 == -1 ? IDENTITY_MAT4 : get_tex_matrix(tmi0));
+			shader.set_uniform_mat4('u_tex_matrix2', false, tmi1 == -1 ? IDENTITY_MAT4 : get_tex_matrix(tmi1));
 
 			// mesh color (white for now)
 			shader.set_uniform_4f('u_mesh_color', 1, 1, 1, 1);
@@ -1514,6 +1535,7 @@ class M2RendererGL {
 			}
 
 			// draw
+			ubo.ubo.bind(0);
 			dc.vao.bind();
 			gl.drawElements(
 				wireframe ? gl.LINES : gl.TRIANGLES,
@@ -1813,7 +1835,10 @@ class M2RendererGL {
 		// vao.dispose() handles vbo/ebo deletion
 		for (const vao of this.vaos)
 			vao.dispose();
+		for (const ubo of this.ubos)
+			ubo.ubo.dispose();
 
+		this.ubos = [];
 		this.vaos = [];
 		this.buffers = [];
 		this.draw_calls = [];

--- a/src/js/3D/renderers/M2RendererGL.js
+++ b/src/js/3D/renderers/M2RendererGL.js
@@ -1450,7 +1450,6 @@ class M2RendererGL {
 		const light_view_y = view_matrix[1] * lx + view_matrix[5] * ly + view_matrix[9] * lz;
 		const light_view_z = view_matrix[2] * lx + view_matrix[6] * ly + view_matrix[10] * lz;
 
-		shader.set_uniform_1i('u_apply_lighting', 1);
 		shader.set_uniform_3f('u_ambient_color', 0.5, 0.5, 0.5);
 		shader.set_uniform_3f('u_diffuse_color', 0.7, 0.7, 0.7);
 		shader.set_uniform_3f('u_light_dir', light_view_x, light_view_y, light_view_z);
@@ -1504,6 +1503,7 @@ class M2RendererGL {
 
 			// mesh color (white for now)
 			shader.set_uniform_4f('u_mesh_color', 1, 1, 1, 1);
+			shader.set_uniform_1i('u_apply_lighting', dc.flags & 0x1 ? 0 : 1);
 
 			// apply blend mode
 			ctx.apply_blend_mode(dc.blend_mode);

--- a/src/js/3D/renderers/M3RendererGL.js
+++ b/src/js/3D/renderers/M3RendererGL.js
@@ -224,10 +224,8 @@ class M3RendererGL {
 			gl.uniformMatrix4fv(loc, false, IDENTITY_MAT4);
 
 		// texture matrix defaults
-		shader.set_uniform_1i('u_has_tex_matrix1', 0);
-		shader.set_uniform_1i('u_has_tex_matrix2', 0);
-		shader.set_uniform_mat4('u_tex_matrix1', false, IDENTITY_MAT4);
-		shader.set_uniform_mat4('u_tex_matrix2', false, IDENTITY_MAT4);
+		shader.set_uniform_1i('u_tex_matrix1_idx', -1);
+		shader.set_uniform_1i('u_tex_matrix2_idx', -1);
 
 		// lighting
 		const lx = 3, ly = -0.7, lz = -2;

--- a/src/js/3D/renderers/M3RendererGL.js
+++ b/src/js/3D/renderers/M3RendererGL.js
@@ -80,9 +80,9 @@ class M3RendererGL {
 		const gl = this.gl;
 
 		// build interleaved vertex buffer matching M2 format
-		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) = 40 bytes
+		// format: position(3f) + normal(3f) + bone_idx(4ub) + bone_weight(4ub) + uv(2f) + uv(2f) = 48 bytes
 		const vertex_count = m3.vertices.length / 3;
-		const stride = 40;
+		const stride = 48;
 		const vertex_data = new ArrayBuffer(vertex_count * stride);
 		const vertex_view = new DataView(vertex_data);
 
@@ -116,6 +116,10 @@ class M3RendererGL {
 			// texcoord
 			vertex_view.setFloat32(offset + 32, m3.uv ? m3.uv[uv_idx] : 0, true);
 			vertex_view.setFloat32(offset + 36, m3.uv ? m3.uv[uv_idx + 1] : 0, true);
+
+			// texcoord2
+			vertex_view.setFloat32(offset + 40, m3.uv2 ? m3.uv2[uv_idx] : 0, true);
+			vertex_view.setFloat32(offset + 44, m3.uv2 ? m3.uv2[uv_idx + 1] : 0, true);
 		}
 
 		// create VAO

--- a/src/js/3D/renderers/MDXRendererGL.js
+++ b/src/js/3D/renderers/MDXRendererGL.js
@@ -688,10 +688,8 @@ class MDXRendererGL {
 				gl.uniformMatrix4fv(loc, false, this.node_matrices);
 		}
 
-		shader.set_uniform_1i('u_has_tex_matrix1', 0);
-		shader.set_uniform_1i('u_has_tex_matrix2', 0);
-		shader.set_uniform_mat4('u_tex_matrix1', false, IDENTITY_MAT4);
-		shader.set_uniform_mat4('u_tex_matrix2', false, IDENTITY_MAT4);
+		shader.set_uniform_1i('u_tex_matrix1_idx', -1);
+		shader.set_uniform_1i('u_tex_matrix2_idx', -1);
 
 		// lighting
 		const lx = 3, ly = -0.7, lz = -2;

--- a/src/js/3D/renderers/MDXRendererGL.js
+++ b/src/js/3D/renderers/MDXRendererGL.js
@@ -15,6 +15,7 @@ const VertexArray = require('../gl/VertexArray');
 const GLTexture = require('../gl/GLTexture');
 
 const textureRibbon = require('../../ui/texture-ribbon');
+const UniformBuffer = require('../gl/UniformBuffer');
 
 const IDENTITY_MAT4 = new Float32Array([
 	1, 0, 0, 0,
@@ -143,6 +144,7 @@ class MDXRendererGL {
 		this.syncID = -1;
 
 		// rendering
+		this.ubos = [];
 		this.vaos = [];
 		this.textures = new Map();
 		this.default_texture = null;
@@ -244,29 +246,41 @@ class MDXRendererGL {
 		}
 	}
 
+	_create_bones_ubo() {
+		this.shader.bind_uniform_block("VsBoneUbo", 0);
+		const ubosize = this.shader.get_uniform_block_param("VsBoneUbo", this.gl.UNIFORM_BLOCK_DATA_SIZE);
+		const offsets = this.shader.get_active_uniform_offsets(["u_bone_matrices"]);
+		const ubo = new UniformBuffer(this.ctx, ubosize);
+		this.ubos.push({
+			ubo: ubo,
+			offsets: offsets
+		});
+
+		this.node_matrices = ubo.get_float32_view(offsets[0], (ubosize - offsets[0]) / 4);
+
+		const bone_count = Math.min(this.nodes ? this.nodes.length : 0, this.node_matrices.length / 16);
+		// initialize to identity
+		for (let i = 0; i < bone_count; i++) {
+			const offset = i * 16;
+			this.node_matrices.set(IDENTITY_MAT4, offset);
+		}
+	}
+
 	_create_skeleton() {
 		const nodes = this.mdx.nodes;
 
 		if (!nodes || nodes.length === 0) {
 			this.nodes = null;
-			this.node_matrices = new Float32Array(16);
 			return;
 		}
 
 		// flatten nodes array (may have gaps)
 		this.nodes = [];
-		let maxId = 0;
 		for (let i = 0; i < nodes.length; i++) {
 			if (nodes[i]) {
 				this.nodes.push(nodes[i]);
-				if (nodes[i].objectId > maxId)
-					maxId = nodes[i].objectId;
 			}
 		}
-
-		this.node_matrices = new Float32Array((maxId + 1) * 16);
-		for (let i = 0; i <= maxId; i++)
-			this.node_matrices.set(IDENTITY_MAT4, i * 16);
 	}
 
 	_build_geometry() {
@@ -369,6 +383,8 @@ class MDXRendererGL {
 
 			this.vaos.push(vao);
 
+			this._create_bones_ubo();
+
 			// material/texture
 			const material = mdx.materials[geoset.materialId];
 			let textureId = null;
@@ -415,9 +431,7 @@ class MDXRendererGL {
 		this.animation_paused = false;
 
 		if (this.nodes) {
-			const maxId = (this.node_matrices.length / 16) - 1;
-			for (let i = 0; i <= maxId; i++)
-				this.node_matrices.set(IDENTITY_MAT4, i * 16);
+			this.node_matrices.set(IDENTITY_MAT4);
 		}
 	}
 
@@ -681,15 +695,15 @@ class MDXRendererGL {
 		shader.set_uniform_1f('u_time', performance.now() * 0.001);
 
 		// bone matrices (mdx uses node-based skeleton)
-		shader.set_uniform_1i('u_bone_count', this.nodes ? this.nodes.length : 0);
+		const ubo = this.ubos[0];
+		const node_count = this.nodes ? this.nodes.length : 0;
+		shader.set_uniform_1i('u_bone_count', node_count);
 		if (this.nodes && this.node_matrices) {
-			const loc = shader.get_uniform_location('u_bone_matrices');
-			if (loc !== null)
-				gl.uniformMatrix4fv(loc, false, this.node_matrices);
+			ubo.ubo.upload_range(ubo.offsets[0], node_count * 16 * 4);
 		}
 
-		shader.set_uniform_1i('u_tex_matrix1_idx', -1);
-		shader.set_uniform_1i('u_tex_matrix2_idx', -1);
+		shader.set_uniform_mat4('u_tex_matrix1', false, IDENTITY_MAT4);
+		shader.set_uniform_mat4('u_tex_matrix2', false, IDENTITY_MAT4);
 
 		// lighting
 		const lx = 3, ly = -0.7, lz = -2;
@@ -744,6 +758,7 @@ class MDXRendererGL {
 			this.default_texture.bind(2);
 			this.default_texture.bind(3);
 
+			ubo.ubo.bind(0);
 			dc.vao.bind();
 			gl.drawElements(
 				wireframe ? gl.LINES : gl.TRIANGLES,

--- a/src/js/db/caches/DBItemDisplayInfoModelMatRes.js
+++ b/src/js/db/caches/DBItemDisplayInfoModelMatRes.js
@@ -1,0 +1,61 @@
+/*!
+	wow.export (https://github.com/Kruithne/wow.export)
+	License: MIT
+ */
+const log = require('../../log');
+const db2 = require('../../casc/db2');
+const DBTextureFileData = require('./DBTextureFileData');
+
+const itemDisplays = new Map();
+let is_initialized = false;
+
+/**
+ * Initialize Item Display Info Model Mat Res DB2.
+ */
+const initializeIDIMMR = async () => {
+	if (is_initialized)
+		return;
+
+	await DBTextureFileData.ensureInitialized();
+
+	log.write('Loading item display info model mat res...');
+
+	for (const [id, row] of await db2.ItemDisplayInfoModelMatRes.getAllRows()) {
+		const id = row.ID;
+		if (id === 0)
+			continue;
+		const itemdisplayinfoid = row.ItemDisplayInfoID;
+		const matresid = row.MaterialResourcesID;
+		const textureFileDataIDs = DBTextureFileData.getTextureFDIDsByMatID(matresid);
+
+		if (textureFileDataIDs !== undefined) {
+			if (itemDisplays.has(itemdisplayinfoid))
+				itemDisplays.get(itemdisplayinfoid).push(...textureFileDataIDs);
+			else
+				itemDisplays.set(itemdisplayinfoid, [...textureFileDataIDs]);
+		}
+	}
+
+	log.write('Loaded %d item display info model mat res items', itemDisplays.size);
+	is_initialized = true;
+};
+
+const ensure_initialized = async () => {
+	if (!is_initialized)
+		await initializeIDIMMR();
+};
+
+/**
+ * Get texturefile id's by ItemDisplayInfoId
+ * @param {number} ItemDisplayInfoId
+ * @returns {number[]|undefined}
+ */
+const getItemDisplayIdTextureFileIds = (ItemDisplayInfoId) => {
+	return itemDisplays.get(ItemDisplayInfoId);
+};
+
+module.exports = {
+	initialize: initializeIDIMMR,
+	ensureInitialized: ensure_initialized,
+	getItemDisplayIdTextureFileIds,
+};

--- a/src/js/db/caches/DBItemDisplays.js
+++ b/src/js/db/caches/DBItemDisplays.js
@@ -7,7 +7,7 @@
 const log = require('../../log');
 const db2 = require('../../casc/db2');
 const DBModelFileData = require('./DBModelFileData');
-const DBTextureFileData = require('./DBTextureFileData');
+const DBItemDisplayInfoModelMatRes = require('./DBItemDisplayInfoModelMatRes');
 
 const itemDisplays = new Map();
 let initialized = false;
@@ -19,7 +19,7 @@ const initializeItemDisplays = async () => {
 	if (initialized)
 		return;
 
-	await DBTextureFileData.ensureInitialized();
+	await DBItemDisplayInfoModelMatRes.ensureInitialized();
 
 	log.write('Loading item textures...');
 
@@ -34,12 +34,14 @@ const initializeItemDisplays = async () => {
 			continue;
 
 		const modelFileDataIDs = DBModelFileData.getModelFileDataID(modelResIDs[0]);
-		const textureFileDataIDs = DBTextureFileData.getTextureFDIDsByMatID(matResIDs[0]);
 
-		if (modelFileDataIDs !== undefined && textureFileDataIDs !== undefined) {
+		if (modelFileDataIDs !== undefined) {
 			for (const modelFileDataID of modelFileDataIDs) {
-				const display = { ID: itemDisplayInfoID, textures: textureFileDataIDs};
+				const itemDisplayTexFileDataIDs = DBItemDisplayInfoModelMatRes.getItemDisplayIdTextureFileIds(itemDisplayInfoID);
+				if (itemDisplayTexFileDataIDs === undefined)
+					continue;
 
+				const display = { ID: itemDisplayInfoID, textures: itemDisplayTexFileDataIDs };
 				if (itemDisplays.has(modelFileDataID))
 					itemDisplays.get(modelFileDataID).push(display);
 				else

--- a/src/js/db/caches/DBItemModels.js
+++ b/src/js/db/caches/DBItemModels.js
@@ -7,7 +7,7 @@
 const log = require('../../log');
 const db2 = require('../../casc/db2');
 const DBModelFileData = require('./DBModelFileData');
-const DBTextureFileData = require('./DBTextureFileData');
+const DBItemDisplayInfoModelMatRes = require('./DBItemDisplayInfoModelMatRes');
 const DBComponentModelFileData = require('./DBComponentModelFileData');
 
 // maps ItemID -> ItemDisplayInfoID
@@ -30,8 +30,8 @@ const initialize = async () => {
 		log.write('Loading item models...');
 
 		await DBModelFileData.initializeModelFileData();
-		await DBTextureFileData.ensureInitialized();
 		await DBComponentModelFileData.initialize();
+		await DBItemDisplayInfoModelMatRes.ensureInitialized();
 
 		// build item -> appearance -> display chain
 		const appearance_map = new Map();
@@ -68,13 +68,11 @@ const initialize = async () => {
 			if (model_options.every(arr => arr.length === 0))
 				continue;
 
-			// get texture file data IDs from material resources
-			const mat_res_ids = row.ModelMaterialResourcesID.filter(e => e > 0);
+			// get texture file data IDs from display id
 			const texture_file_data_ids = [];
-			for (const mat_res_id of mat_res_ids) {
-				const tex_fdids = DBTextureFileData.getTextureFDIDsByMatID(mat_res_id);
-				if (tex_fdids && tex_fdids.length > 0)
-					texture_file_data_ids.push(tex_fdids[0]);
+			const itemDisplayTexFileDataIDs = DBItemDisplayInfoModelMatRes.getItemDisplayIdTextureFileIds(display_id);
+			if (itemDisplayTexFileDataIDs !== undefined) {
+				texture_file_data_ids.push(...itemDisplayTexFileDataIDs);
 			}
 
 			// geoset groups for character model and attachment/collection models

--- a/src/js/modules/tab_characters.js
+++ b/src/js/modules/tab_characters.js
@@ -618,8 +618,8 @@ async function update_equipment_models(core) {
 					const is_collection_style = false;
 
 					// apply textures
-					if (display.textures && display.textures.length > i)
-						await renderer.applyReplaceableTextures({ textures: [display.textures[i]] });
+					if (display.textures)
+						await renderer.applyReplaceableTextures({ textures: display.textures });
 
 					renderers.push({ renderer, attachment_id, is_collection_style });
 					log.write('Loaded attachment model %d for slot %d attachment %d (item %d)', file_data_id, slot_id, attachment_id, item_id);
@@ -661,11 +661,8 @@ async function update_equipment_models(core) {
 					}
 
 					// use matching texture for this model index
-					const texture_idx = i < display.textures?.length ? i : 0;
-					const texture_fdid = display.textures?.[texture_idx];
-
-					if (texture_fdid)
-						await renderer.applyReplaceableTextures({ textures: [texture_fdid] });
+					if (display.textures)
+						await renderer.applyReplaceableTextures({ textures: display.textures });
 
 					renderers.push(renderer);
 					log.write('Loaded collection model %d for slot %d (item %d)', file_data_id, slot_id, item_id);

--- a/src/shaders/m2.vertex.shader
+++ b/src/shaders/m2.vertex.shader
@@ -18,15 +18,14 @@ uniform vec3 u_view_up;
 uniform float u_time;
 
 // bone matrices (max 256 bones)
-#define MAX_BONES 256
-uniform mat4 u_bone_matrices[MAX_BONES];
 uniform int u_bone_count;
-
+#define MAX_BONES 256
+uniform VsBoneUbo {
+	mat4 u_bone_matrices[MAX_BONES];
+};
 // texture transform matrices
-uniform int u_tex_matrix1_idx;
-uniform int u_tex_matrix2_idx;
-#define MAX_MATRICES 64
-uniform mat4 u_tex_matrices[MAX_MATRICES];
+uniform mat4 u_tex_matrix1;
+uniform mat4 u_tex_matrix2;
 
 // vertex shader mode
 uniform int u_vertex_shader;
@@ -89,8 +88,8 @@ void main() {
 	v_edge_fade = 1.0;
 
 	// apply texture matrix transforms
-	mat4 tex_mat1 = u_tex_matrix1_idx < 0 ? mat4(1.0) : u_tex_matrices[u_tex_matrix1_idx];
-	mat4 tex_mat2 = u_tex_matrix2_idx < 0 ? mat4(1.0) : u_tex_matrices[u_tex_matrix2_idx];
+	mat4 tex_mat1 = u_tex_matrix1;
+	mat4 tex_mat2 = u_tex_matrix2;
 
 	v_texcoord = a_texcoord;
 	v_texcoord2 = vec2(0.0);

--- a/src/shaders/m2.vertex.shader
+++ b/src/shaders/m2.vertex.shader
@@ -23,10 +23,10 @@ uniform mat4 u_bone_matrices[MAX_BONES];
 uniform int u_bone_count;
 
 // texture transform matrices
-uniform mat4 u_tex_matrix1;
-uniform mat4 u_tex_matrix2;
-uniform int u_has_tex_matrix1;
-uniform int u_has_tex_matrix2;
+uniform int u_tex_matrix1_idx;
+uniform int u_tex_matrix2_idx;
+#define MAX_MATRICES 64
+uniform mat4 u_tex_matrices[MAX_MATRICES];
 
 // vertex shader mode
 uniform int u_vertex_shader;
@@ -89,8 +89,8 @@ void main() {
 	v_edge_fade = 1.0;
 
 	// apply texture matrix transforms
-	mat4 tex_mat1 = u_has_tex_matrix1 != 0 ? u_tex_matrix1 : mat4(1.0);
-	mat4 tex_mat2 = u_has_tex_matrix2 != 0 ? u_tex_matrix2 : mat4(1.0);
+	mat4 tex_mat1 = u_tex_matrix1_idx < 0 ? mat4(1.0) : u_tex_matrices[u_tex_matrix1_idx];
+	mat4 tex_mat2 = u_tex_matrix2_idx < 0 ? mat4(1.0) : u_tex_matrices[u_tex_matrix2_idx];
 
 	v_texcoord = a_texcoord;
 	v_texcoord2 = vec2(0.0);


### PR DESCRIPTION
Hi, 
In finding and playing around with this tool/project, i noticed rendering of druid firecat was, a bit off, and took a shot at fixing it 😸 (fandralfirecatnoarmor.m2), also used (staff_2h_etherealraid_d_02.m2) as main goal to fix. Alot of this was based on things like <https://wowdev.wiki/M2>

I split up commits to be smol and atomic but they are a bit 'out of order' thought wise, but basically issues for firecat were
 - 'Texcoord2' from m2 file wasnt being used/rendered ( for full reasons im not sure about based on staff model, for render it seems y coord on that does *not* need flipping, however ive only changed it in m2renderer to avoid any export changes, and 'reflipped' it during `m2renderer.loadSkin` )
 - 'tex_matrixs' weren't being used, but also needed to be animated based on globalloops

Trying to tackle staff_2h_etherealraid_d_02.m2 lead to a few more fixes
 - it needed some missing textures, using `ItemDisplayInfoModelMatRes` table instead seems to give same textures as other table and includes missing textures when used as 'replacements'
 - blend mode mapping needed to be translated from m2 to egx which `apply_blend_mode` looks to be based on
 - draw call ordering needed to be based on a few other things in the texunit, namely `priority` and `materialLayer`

last commit, semi working around webgl restrictions
- reworks bones into a ubo, and tweaks tex_matrices back into just uploading the given two that matter to not make restriction counts worse

That seems to fix those two models, at least in rendering, didn't touch export, however those should be 'better' in some cases as they now include some missing textures. Wmo/m3 still render as well, however i wasnt able to test legacy in case of any issues there

One other finding related to staff_2h_etherealraid_d_02 that i noticed and just wanted to mention, but is more involved to change, is currently `subMeshes` is used to signify drawcalls, but instead it should be `textureUnits` (or M2Batch on wiki) that equivalate to drawcalls, for example with that staff, an extra drawcall is missing using the crystal mesh, making it a bit less opaque on top of whats there ( i forgot the exact blend/params )