### PR TITLE
Fix macOS build -- native addon, mmap path, install path, manifest

### DIFF
--- a/build.json
+++ b/build.json
@@ -7,7 +7,7 @@
 	"manifest": {
 		"name": "wow.export",
 		"main": "./src/index.html",
-		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging --password-store=basic",
+		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging --password-store=basic --disable-features=ProfileNetworkContextService",
 		"product_string": "wow.export",
 		"user-agent": "wow.export (%ver); %osinfo",
 		"window": {

--- a/build.json
+++ b/build.json
@@ -7,7 +7,7 @@
 	"manifest": {
 		"name": "wow.export",
 		"main": "./src/index.html",
-		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging --password-store=basic --disable-features=ProfileNetworkContextService",
+		"chromium-args": "--disable-devtools --disable-raf-throttling --mixed-context --enable-node-worker --disable-logging --password-store=basic",
 		"product_string": "wow.export",
 		"user-agent": "wow.export (%ver); %osinfo",
 		"window": {

--- a/build/build-native-addons.js
+++ b/build/build-native-addons.js
@@ -187,9 +187,14 @@ function rebuild_addon(addon_dir) {
 		`--nodedir=${node_dir}`
 	];
 
-	execFileSync('npx', ['nw-gyp', ...args], {
+	execFileSync('node-gyp', [...args, `--arch=${process.arch}`], {
 		cwd: addon_dir,
-		stdio: 'inherit'
+		stdio: 'inherit',
+		env: {
+			...process.env,
+			npm_config_runtime: 'node-webkit',
+			npm_config_target: nw_version
+		}
 	});
 }
 

--- a/src/js/casc/dbd-manifest.js
+++ b/src/js/casc/dbd-manifest.js
@@ -51,6 +51,9 @@ async function prepareManifest() {
 	if (is_preloaded)
 		return true;
 
+	if (preload_promise === null)
+		preload();
+
 	await preload_promise;
 	return true;
 }

--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -9,9 +9,10 @@ const path = require('path');
 const os = require('os');
 
 // on macOS, process.execPath points to the renderer helper binary deep inside
-// the framework, not the app root. use __dirname (app.nw/src/) instead.
+// the framework, not the app root. __dirname is src/js/, so go up two levels
+// to reach the package root (app.nw/ in production, repo root in dev).
 const INSTALL_PATH = process.platform === 'darwin'
-	? path.resolve(path.join(__dirname, '..'))
+	? path.resolve(path.join(__dirname, '..', '..'))
 	: path.dirname(process.execPath);
 const DATA_PATH = nw.App.dataPath;
 

--- a/src/js/mmap.js
+++ b/src/js/mmap.js
@@ -5,11 +5,44 @@
  */
 const path = require('path');
 const log = require('./log');
-const INSTALL_PATH = process.platform === 'darwin'
-	? path.resolve(path.join(__dirname, '..'))
-	: path.dirname(process.execPath);
+const fs = require('fs');
 
-const mmap_native = require(path.join(INSTALL_PATH, 'mmap.node'));
+/**
+ * Locate mmap.node native addon.
+ *
+ * On macOS, Bun inlines __dirname at bundle time as a hardcoded path from
+ * the build machine's source tree. At runtime inside the .app bundle this
+ * path is wrong, so we resolve relative to process.execPath instead.
+ *
+ * The search covers three cases:
+ *   1. Next to the executable (Windows, Linux)
+ *   2. In the main app bundle Resources/app.nw/src/ (macOS main process)
+ *   3. Same as #2 but reached from a helper process deep in Frameworks/
+ */
+const resolve_mmap_path = () => {
+	const execDir = path.dirname(process.execPath);
+	const candidates = [
+		path.join(execDir, 'mmap.node'),
+	];
+
+	// Walk up from execPath looking for a directory that contains
+	// Contents/Resources/app.nw/src/mmap.node (the macOS app bundle).
+	let dir = execDir;
+	for (let i = 0; i < 15; i++) {
+		candidates.push(path.join(dir, 'Contents', 'Resources', 'app.nw', 'src', 'mmap.node'));
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+
+	for (const candidate of candidates) {
+		try { if (fs.existsSync(candidate)) return candidate; } catch {}
+	}
+
+	throw new Error('mmap.node not found. Searched:\n' + candidates.join('\n'));
+};
+
+const mmap_native = require(resolve_mmap_path());
 
 const virtual_files = new Set();
 

--- a/src/shaders/m2.vertex.shader
+++ b/src/shaders/m2.vertex.shader
@@ -17,8 +17,9 @@ uniform mat4 u_model_matrix;
 uniform vec3 u_view_up;
 uniform float u_time;
 
-// bone matrices (max 256 bones)
-#define MAX_BONES 256
+// bone matrices -- macOS WebGL2 caps at 1024 vec4 uniforms total,
+// 256 mat4 bones (1024 vec4) + other uniforms exceeds that limit.
+#define MAX_BONES 220
 uniform mat4 u_bone_matrices[MAX_BONES];
 uniform int u_bone_count;
 


### PR DESCRIPTION
## Summary

Five fixes for building and running wow.export on macOS (including Apple Silicon ARM64):

1. **Replace nw-gyp with node-gyp** (`build/build-native-addons.js`) -- nw-gyp@3.6.8 requires Python 2 which is EOL. node-gyp@12+ works with Python 3 and compiles NAPI addons identically.

2. **Fix mmap.node path resolution** (`src/js/mmap.js`) -- Bun inlines `__dirname` at bundle time as a hardcoded path from the build machine. Replaced with `process.execPath` walk-up that finds the .app bundle at runtime from any process (main or helper).

3. **Fix INSTALL_PATH depth** (`src/js/constants.js`) -- `__dirname` is `src/js/`, so one `..` gives `src/` not the package root. Changed to `../..` to correctly reach the root. This was the root cause of `default_config.jsonc` failing to load, which left all config URLs undefined and broke manifest downloads, listfile loading, and DB2 file resolution (the "file not mapping in listfile: DBFilesClient/ModelFileData.db2" error).

4. **Ensure DBD manifest preload** (`src/js/casc/dbd-manifest.js`) -- `prepareManifest()` now calls `preload()` if it hasn't been triggered, preventing empty manifest when called before app-level init.

5. **Fix M2 shader uniform overflow** (`src/shaders/m2.vertex.shader`) -- macOS WebGL2 caps `GL_MAX_VERTEX_UNIFORM_VECTORS` at 1024. The M2 vertex shader used 256 mat4 bone matrices (1024 vec4) plus ~25 other uniforms, exceeding the limit. Reduced `MAX_BONES` from 256 to 220, bringing total to ~905 vec4. Most WoW models use far fewer than 220 bones.

## Testing

Tested on macOS 15.x (Darwin 25.2.0) ARM64 with:
- Bun 1.3.12
- node-gyp 12.2.0
- Python 3.14.3
- nw.js 0.104.1 (ARM64)

Full model browser working with M2 and WMO 3D preview, local CASC source, DB2 resolution.

## Related

- Addresses #472 (macOS version corrupt)
- Related to #557 (osx arm64 pipeline)
- Related to #549 (ARM64 Mac support)