### PR TITLE
Filter body-overlay rows on TBC Anniversary

### DIFF
--- a/src/js/modules/tab_characters.js
+++ b/src/js/modules/tab_characters.js
@@ -478,9 +478,31 @@ async function update_textures(core) {
 				}
 			}
 
+			// TBC Anniversary's ItemDisplayInfoMaterialRes has legacy/set-mate
+			// rows that don't match in-game rendering: M2-attachment slots
+			// (helms/shoulders/weapons/back) reference body overlays, and
+			// belts/gloves/etc. reference shared chest BLPs instead of
+			// piece-specific textures. Filter these on this client only.
+			// Section IDs: 0=ArmUpper 1=ArmLower 2=Hand 3=TorsoUpper
+			//              4=TorsoLower 5=LegUpper 6=LegLower 7=Foot 8=Accessory
+			const is_tbc_anniversary = core.view.casc?.build?.Product === 'wow_anniversary';
+			const M2_ONLY_SLOTS = new Set([1, 3, 15, 16, 17, 30]);
+			const ALLOWED_SECTIONS_PER_SLOT = {
+				4:  new Set([0, 1, 3, 4]),  // shirt
+				5:  new Set([0, 1, 3, 4]),  // chest
+				6:  new Set([5]),           // belt (section 4 row is a bogus chest-share)
+				7:  new Set([4, 5, 6]),     // legs
+				8:  new Set([6, 7]),        // boots
+				9:  new Set([1]),           // bracers
+				10: new Set([1, 2]),        // gloves
+				19: new Set([3, 4])         // tabard (custom pipeline elsewhere)
+			};
+
 			for (const [slot_id, item_id] of Object.entries(equipped_items)) {
 				// guild tabards use custom composition pipeline
 				if (DBGuildTabard.isGuildTabard(item_id))
+					continue;
+				if (is_tbc_anniversary && M2_ONLY_SLOTS.has(Number(slot_id)))
 					continue;
 
 				const modifier_id = item_skins?.[slot_id];
@@ -489,7 +511,11 @@ async function update_textures(core) {
 				if (!item_textures)
 					continue;
 
+				const allowed_sections = is_tbc_anniversary ? ALLOWED_SECTIONS_PER_SLOT[Number(slot_id)] : undefined;
+
 				for (const texture of item_textures) {
+					if (allowed_sections && !allowed_sections.has(texture.section))
+						continue;
 					const section = section_by_type.get(texture.section);
 					if (!section)
 						continue;


### PR DESCRIPTION
On the wow_anniversary (TBC Classic Anniversary, build 2.5.5.67852) client, ItemDisplayInfoMaterialRes ships rows that don't match how the items render in-game:

1. Many helms, shoulders, weapons, and cape items have body section overlay rows (apparent legacy hood/cowl/scabbard data) that the bake layers onto the character composite. These slots render entirely as attached M2 models in-game, so the overlays produce visible chest/leg bleed-through that doesn't exist in the actual game client.

2. Many belts, boots, gloves, and other accessory items have set-mate sharing rows that point at the matching chest piece's BLP rather than a piece-specific texture. The bake faithfully draws the shared BLP onto the canvas, overpainting the chest item's bake with a near-identical-but-not-quite chest texture. The most visible case is Belt of the Guardian (item 30034), where the belt's only ItemDisplayInfoMaterialRes row is section 4 (TorsoLower) pointing at plate_a_01black_chest_tl_u.blp; with no actual belt-strip art referenced anywhere in the modern MaterialRes data, the bake produces "chest texture in belt region" instead of the belt visual.

The legacy filename-prefix lookup that the real client appears to use to fill in the missing belt/glove/etc. textures isn't implemented in wow.export, so we can't reconstruct the correct overlays for these items. Filter the spurious rows instead: M2-only slots skip the body-overlay loop entirely, and each remaining slot is restricted to the body sections it actually paints in-game.

Gated by Product === 'wow_anniversary' to scope the change to where it was empirically validated. Other Classic flavors very likely have the same legacy data shape, but I don't have a repro on hand to confirm; broadening the gate is a one-line change once someone does.

Repro and validation: TBC Anniversary client, Blood Elf male, Crystalforge Battlegear paladin set + Belt of the Guardian. Before: Crystalforge Faceguard equip alone produces plate_a_01crusader_* chest/leg loads in the runtime log and visible chest art on the body; Belt of the Guardian alone produces a chest BLP painted onto the torso with no visible belt strip. After: helm equip touches only head M2 attachments; belt equip contributes nothing to the body composite (chest item renders unobstructed; belt strip is not reconstructed -- see the open issue).