### PR TITLE
Fix OOM crash exporting large WMOs

### DIFF
--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -281,8 +281,10 @@ class WMOExporter {
 			groups.push(group);
 		}
 
-		const vertices = new Array(nInd * 3);
-		const normals = new Array(nInd * 3);
+		// Typed arrays to keep large WMO geometry within the heap (see the OBJ
+		// path above for the rationale).
+		const vertices = new Float32Array(nInd * 3);
+		const normals = new Float32Array(nInd * 3);
 
 		const uv_maps = [];
 
@@ -306,7 +308,7 @@ class WMOExporter {
 			if (group.uvs) {
 				for (let i = 0, n = group.uvs.length; i < n; i++) {
 					if (!uv_maps[i])
-						uv_maps[i] = new Array(indCount * 2).fill(0);
+						uv_maps[i] = new Float32Array(indCount * 2);
 
 					const uv = group.uvs[i];
 					const uv_map = uv_maps[i];
@@ -443,17 +445,21 @@ class WMOExporter {
 		if (!core.view.config.modelsExportUV2)
 			maxLayerCount = Math.min(maxLayerCount, 1);
 
-		const vertsArray = new Array(nInd * 3);
-		const normalsArray = new Array(nInd * 3);
+		// Use typed arrays rather than plain JS arrays. A boxed-float JS array
+		// costs ~8 bytes/element plus object overhead; a Float32Array is 4 bytes
+		// with no boxing. Large WMOs (e.g. a raid with millions of triangles)
+		// otherwise exhaust the heap building these vertex/normal/uv buffers.
+		const vertsArray = new Float32Array(nInd * 3);
+		const normalsArray = new Float32Array(nInd * 3);
 		const uvArrays = new Array(maxLayerCount);
 
 		// Create all necessary UV layer arrays.
 		for (let i = 0; i < maxLayerCount; i++)
-			uvArrays[i] = new Array(nInd * 2);
+			uvArrays[i] = new Float32Array(nInd * 2);
 
 		// colors2 provides vertex blend weights for shader 20.
 		const hasColors2 = groups.some(g => g.colors2);
-		const colorsArray = hasColors2 ? new Array(nInd * 4).fill(0) : null;
+		const colorsArray = hasColors2 ? new Float32Array(nInd * 4) : null;
 
 		// Iterate over groups again and fill the allocated arrays.
 		let indOfs = 0;
@@ -811,8 +817,8 @@ class WMOExporter {
 			groups.push(group);
 		}
 
-		const vertsArray = new Array(nInd * 3);
-		const normalsArray = new Array(nInd * 3);
+		const vertsArray = new Float32Array(nInd * 3);
+		const normalsArray = new Float32Array(nInd * 3);
 
 		// iterate over groups again and fill the allocated arrays
 		let indOfs = 0;

--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -392,10 +392,6 @@ class WMOExporter {
 		for (const [texFileDataID, texInfo] of textureMap)
 			fileManifest?.push({ type: 'PNG', fileDataID: texFileDataID, file: texInfo.matPath });
 
-		const groups = [];
-		let nInd = 0;
-		let maxLayerCount = 0;
-
 		let mask;
 
 		// Map our user-facing group mask to a WMO mask.
@@ -408,123 +404,84 @@ class WMOExporter {
 				}
 			}
 		}
-	
+
 		helper.setCurrentTaskName(wmoName + ' groups');
 		helper.setCurrentTaskMax(wmo.groupCount);
 
-		// Iterate over the groups once to calculate the total size of our
-		// vertex/normal/uv arrays allowing for pre-allocation.
-		for (let i = 0, n = wmo.groupCount; i < n; i++) {
-			// Abort if the export has been cancelled.
-			if (helper.isCancelled())
-				return;
+		// Whether additional UV layers beyond the first are exported.
+		const exportUV2 = core.view.config.modelsExportUV2;
 
-			helper.setCurrentTaskValue(i);
+		// Stream the geometry group-by-group rather than merging every group into
+		// one giant vertex/normal/uv buffer up front. A raid-sized WMO is several
+		// million vertices; building the merged buffers (and retaining every
+		// group's source arrays plus every batch's index array until the final
+		// write) exhausts the V8 renderer heap. This generator fetches one group
+		// at a time, transforms just that group's geometry, yields it to the
+		// writer, and lets it be reclaimed before moving on - so peak memory is a
+		// single group, not the whole model.
+		async function* streamGroups() {
+			for (let i = 0, n = wmo.groupCount; i < n; i++) {
+				if (helper.isCancelled())
+					return;
 
-			const group = await wmo.getGroup(i);
+				helper.setCurrentTaskValue(i);
 
-			// Skip empty groups.
-			if (!group.renderBatches || group.renderBatches.length === 0)
-				continue;
+				const group = await wmo.getGroup(i);
 
-			// Skip masked groups.
-			if (mask && !mask.has(i))
-				continue;
+				// Skip empty groups.
+				if (!group.renderBatches || group.renderBatches.length === 0)
+					continue;
 
-			// 3 verts per indices.
-			nInd += group.vertices.length / 3;
+				// Skip masked groups.
+				if (mask && !mask.has(i))
+					continue;
 
-			// UV counts vary between groups, allocate for the max.
-			maxLayerCount = Math.max(group.uvs.length, maxLayerCount);
+				const indCount = group.vertices.length / 3;
+				const groupName = wmo.groupNames[group.nameOfs];
 
-			// Store the valid groups for quicker iteration later.
-			groups.push(group);
-		}
+				// UV layers for this group (optionally limited to the first).
+				let uvs = group.uvs ?? [];
+				if (!exportUV2 && uvs.length > 1)
+					uvs = [uvs[0]];
 
-		// Restrict to first UV layer if additional UV layers are not enabled.
-		if (!core.view.config.modelsExportUV2)
-			maxLayerCount = Math.min(maxLayerCount, 1);
-
-		// Use typed arrays rather than plain JS arrays. A boxed-float JS array
-		// costs ~8 bytes/element plus object overhead; a Float32Array is 4 bytes
-		// with no boxing. Large WMOs (e.g. a raid with millions of triangles)
-		// otherwise exhaust the heap building these vertex/normal/uv buffers.
-		const vertsArray = new Float32Array(nInd * 3);
-		const normalsArray = new Float32Array(nInd * 3);
-		const uvArrays = new Array(maxLayerCount);
-
-		// Create all necessary UV layer arrays.
-		for (let i = 0; i < maxLayerCount; i++)
-			uvArrays[i] = new Float32Array(nInd * 2);
-
-		// colors2 provides vertex blend weights for shader 20.
-		const hasColors2 = groups.some(g => g.colors2);
-		const colorsArray = hasColors2 ? new Float32Array(nInd * 4) : null;
-
-		// Iterate over groups again and fill the allocated arrays.
-		let indOfs = 0;
-		for (const group of groups) {
-			const indCount = group.vertices.length / 3;
-
-			const vertOfs = indOfs * 3;
-			const groupVerts = group.vertices;
-			for (let i = 0, n = groupVerts.length; i < n; i++)
-				vertsArray[vertOfs + i] = groupVerts[i];
-
-			// Normals and vertices should match, so re-use vertOfs here.
-			const groupNormals = group.normals;
-			for (let i = 0, n = groupNormals.length; i < n; i++)
-				normalsArray[vertOfs + i] = groupNormals[i];
-
-			const uvsOfs = indOfs * 2;
-			const groupUVs = group.uvs ?? [];
-			const uvCount = indCount * 2;
-
-			// Write to all UV layers, even if we have no data.
-			for (let i = 0; i < maxLayerCount; i++) {
-				const uv = groupUVs[i];
-				for (let j = 0; j < uvCount; j++)
-					uvArrays[i][uvsOfs + j] = uv?.[j] ?? 0;
-			}
-
-			// colors2 (BGRA uint8) → RGBA float for shader 20 blend weights.
-			if (colorsArray && group.colors2) {
-				const colorOfs = indOfs * 4;
-				const src = group.colors2;
-				for (let i = 0; i < indCount; i++) {
-					const si = i * 4, di = colorOfs + i * 4;
-					colorsArray[di] = src[si + 2] / 255;
-					colorsArray[di + 1] = src[si + 1] / 255;
-					colorsArray[di + 2] = src[si] / 255;
-					colorsArray[di + 3] = src[si + 3] / 255;
+				// colors2 (BGRA uint8) -> RGBA float for shader 20 blend weights.
+				let colors = null;
+				if (group.colors2) {
+					colors = new Float32Array(indCount * 4);
+					const src = group.colors2;
+					for (let c = 0; c < indCount; c++) {
+						const si = c * 4, di = c * 4;
+						colors[di] = src[si + 2] / 255;
+						colors[di + 1] = src[si + 1] / 255;
+						colors[di + 2] = src[si] / 255;
+						colors[di + 3] = src[si + 3] / 255;
+					}
 				}
+
+				// Build this group's meshes with group-local (zero-based) indices;
+				// writeStreamingGroups applies the running global offset itself.
+				const meshes = [];
+				for (let bI = 0, bC = group.renderBatches.length; bI < bC; bI++) {
+					const batch = group.renderBatches[bI];
+					const indices = new Uint32Array(batch.numFaces);
+
+					for (let f = 0; f < batch.numFaces; f++)
+						indices[f] = group.indices[batch.firstFace + f];
+
+					const matID = ((batch.flags & 2) === 2) ? batch.possibleBox2[2] : batch.materialID;
+					meshes.push({ name: groupName + bI, triangles: indices, matName: materialMap.get(matID) });
+				}
+
+				yield {
+					verts: group.vertices,
+					normals: group.normals,
+					uvs,
+					colors,
+					meshes,
+					flipUVs: true,
+				};
 			}
-
-			const groupName = wmo.groupNames[group.nameOfs];
-
-			// Load all render batches into the mesh.
-			for (let bI = 0, bC = group.renderBatches.length; bI < bC; bI++) {
-				const batch = group.renderBatches[bI];
-				const indices = new Array(batch.numFaces);
-
-				for (let i = 0; i < batch.numFaces; i++)
-					indices[i] = group.indices[batch.firstFace + i] + indOfs;
-
-				const matID = ((batch.flags & 2) === 2) ? batch.possibleBox2[2] : batch.materialID;
-				obj.addMesh(groupName + bI, indices, materialMap.get(matID));
-			}
-
-			indOfs += indCount;
 		}
-
-		obj.setVertArray(vertsArray);
-		obj.setNormalArray(normalsArray);
-
-		for (const arr of uvArrays)
-			obj.addUVArray(arr);
-
-		if (colorsArray)
-			obj.setColorArray(colorsArray);
 
 		const csvPath = ExportHelper.replaceExtension(out, '_ModelPlacementInformation.csv');
 		if (config.overwriteFiles || !await generics.fileExists(csvPath)) {
@@ -642,7 +599,7 @@ class WMOExporter {
 		if (!mtl.isEmpty)
 			obj.setMaterialLibrary(path.basename(mtl.out));
 
-		await obj.write(config.overwriteFiles);
+		await obj.writeStreamingGroups(streamGroups(), config.overwriteFiles);
 		fileManifest?.push({ type: 'OBJ', fileDataID: this.wmo.fileDataID, file: obj.out });
 
 		await mtl.write(config.overwriteFiles);

--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -480,6 +480,17 @@ class WMOExporter {
 					meshes,
 					flipUVs: true,
 				};
+
+				// Generator execution resumes here only after the writer has fully
+				// consumed the yielded group, so the geometry is safe to release.
+				// WMOLoader.getGroup caches every group it loads and never evicts;
+				// without this, walking all groups leaves the entire model resident
+				// in the loader (boxed vertex/normal/index/uv arrays) - and because a
+				// map export re-runs this per referencing tile, the cache compounds
+				// across passes until the heap is exhausted. Dropping the cache slot
+				// lets it be reclaimed now; getGroup transparently reloads the group
+				// from CASC if a later pass (or the meta writer) needs it again.
+				wmo.groups[i] = null;
 			}
 		}
 
@@ -635,9 +646,13 @@ class WMOExporter {
 			json.addProperty('fog', wmo.fogs);
 			json.addProperty('flags', wmo.flags);
 
-			const groups = Array(wmo.groups.length);
-			for (let i = 0, n = wmo.groups.length; i < n; i++) {
-				const group = wmo.groups[i];
+			const groups = Array(wmo.groupCount);
+			for (let i = 0, n = wmo.groupCount; i < n; i++) {
+				// The streaming write above evicts each group from the loader cache
+				// as it consumes it, so re-fetch here (getGroup reloads from CASC if
+				// the slot was cleared). Keeps peak memory to a single group during
+				// meta export too, rather than the whole model.
+				const group = await wmo.getGroup(i);
 				groups[i] = {
 					groupName: wmo.groupNames[group.nameOfs],
 					groupDescription: wmo.groupNames[group.descOfs],
@@ -659,6 +674,10 @@ class WMOExporter {
 					colors2: group.colors2,
 					liquid: group.liquid
 				};
+
+				// Release the geometry again; the JSON above copied only the light
+				// metadata it needs, not the vertex/normal/index/uv arrays.
+				wmo.groups[i] = null;
 			}
 
 			// Create a textures array and push every unique fileDataID from the

--- a/src/js/3D/writers/OBJWriter.js
+++ b/src/js/3D/writers/OBJWriter.js
@@ -256,11 +256,13 @@ class OBJWriter {
 	 * large models (e.g. raid WMOs of several million vertices) where building a
 	 * single merged buffer plus every retained index array exhausts the V8 heap.
 	 *
-	 * Output is equivalent to write(): each group emits its used verts, normals,
-	 * uvs and (optional) colours, remapped to a compact local numbering, followed
-	 * by its faces. Vertex references in 'f' lines are global 1-based indices, so
-	 * a running offset is carried across groups. Groups are independent (WMO
-	 * groups never share vertices), so no cross-group dedup is needed or lost.
+	 * Output is equivalent to write(): each group emits its used verts, normals
+	 * and uvs, remapped to a compact local numbering, followed by its faces.
+	 * Vertex colours are collected during the pass and written after the last
+	 * group, one line per emitted vertex. Vertex references in 'f' lines are
+	 * global 1-based indices, so a running offset is carried across groups.
+	 * Groups are independent (WMO groups never share vertices), so no
+	 * cross-group dedup is needed or lost.
 	 *
 	 * @param {Iterable|AsyncIterable} groups - yields { verts, normals, uvs,
 	 *   colors, meshes, flipUVs } where meshes is [{ name, triangles, matName }]
@@ -274,123 +276,164 @@ class OBJWriter {
 		await generics.createDirectory(path.dirname(this.out));
 		const writer = new FileWriter(this.out);
 
-		await writer.writeLine('# Exported using wow.export v' + constants.VERSION);
-		await writer.writeLine('o ' + this.name);
+		// Vertex colours are buffered and written after all groups. The Blender
+		// addon pairs vc lines with vertices purely by order, so a group without
+		// colours in the middle of the stream would silently shift every later
+		// colour onto the wrong vertex. Buffering lets those groups be
+		// zero-filled once it is known that any group carries colours, matching
+		// the monolithic writer, at a bounded cost of 16 bytes per emitted
+		// vertex for the groups that have them.
+		const colorBlocks = [];
+		let anyColors = false;
 
-		if (this.mtl)
-			await writer.writeLine('mtllib ' + this.mtl);
+		try {
+			await writer.writeLine('# Exported using wow.export v' + constants.VERSION);
+			await writer.writeLine('o ' + this.name);
 
-		// Running counts of already-emitted verts / normals / uvs / colours so
-		// each group's face indices resolve to the correct global 1-based value.
-		let vertBase = 0;
-		let normalBase = 0;
-		let uvBase = 0;
+			if (this.mtl)
+				await writer.writeLine('mtllib ' + this.mtl);
 
-		for await (const group of groups) {
-			const verts = group.verts;
-			const normals = group.normals;
-			const uvLayers = group.uvs ?? [];
-			const colors = group.colors ?? null;
-			const meshes = group.meshes ?? [];
-			const flipUVs = group.flipUVs ?? this.flip_uvs;
+			// Running counts of already-emitted verts / normals / uvs / colours so
+			// each group's face indices resolve to the correct global 1-based value.
+			let vertBase = 0;
+			let normalBase = 0;
+			let uvBase = 0;
 
-			const layerCount = uvLayers.length;
-			const hasUV = layerCount > 0;
+			for await (const group of groups) {
+				const verts = group.verts;
+				const normals = group.normals;
+				const uvLayers = group.uvs ?? [];
+				const colors = group.colors ?? null;
+				const meshes = group.meshes ?? [];
+				const flipUVs = group.flipUVs ?? this.flip_uvs;
 
-			// Determine which of this group's vertices are actually referenced
-			// by a face, mirroring write()'s culling so output stays identical.
-			const usedIndices = new Set();
-			for (const mesh of meshes) {
-				const tris = mesh.triangles;
-				for (let i = 0, n = tris.length; i < n; i++)
-					usedIndices.add(tris[i]);
-			}
+				const layerCount = uvLayers.length;
+				const hasUV = layerCount > 0;
 
-			// Local (group) index -> compacted position within the emitted block.
-			const vertMap = new Map();
-			const normalMap = new Map();
-			const uvMap = new Map();
-
-			// Verts.
-			for (let i = 0, j = 0, u = 0, n = verts.length; i < n; j++, i += 3) {
-				if (usedIndices.has(j)) {
-					vertMap.set(j, u++);
-					await writer.writeLine('v ' + verts[i] + ' ' + verts[i + 1] + ' ' + verts[i + 2]);
+				// Determine which of this group's vertices are actually referenced
+				// by a face, mirroring write()'s culling so output stays identical.
+				const usedIndices = new Set();
+				for (const mesh of meshes) {
+					const tris = mesh.triangles;
+					for (let i = 0, n = tris.length; i < n; i++)
+						usedIndices.add(tris[i]);
 				}
-			}
 
-			// Normals.
-			for (let i = 0, j = 0, u = 0, n = normals.length; i < n; j++, i += 3) {
-				if (usedIndices.has(j)) {
-					normalMap.set(j, u++);
-					await writer.writeLine('vn ' + normals[i] + ' ' + normals[i + 1] + ' ' + normals[i + 2]);
+				// Local (group) index -> compacted position within the emitted block.
+				const vertMap = new Map();
+				const normalMap = new Map();
+				const uvMap = new Map();
+
+				// Verts.
+				for (let i = 0, j = 0, u = 0, n = verts.length; i < n; j++, i += 3) {
+					if (usedIndices.has(j)) {
+						vertMap.set(j, u++);
+						await writer.writeLine('v ' + verts[i] + ' ' + verts[i + 1] + ' ' + verts[i + 2]);
+					}
 				}
-			}
 
-			// Vertex colours (non-standard, used by the wow.export Blender addon).
-			if (colors) {
-				for (let i = 0, j = 0, n = colors.length; i < n; j++, i += 4) {
-					if (usedIndices.has(j))
-						await writer.writeLine('vc ' + colors[i] + ' ' + colors[i + 1] + ' ' + colors[i + 2] + ' ' + colors[i + 3]);
+				// Normals.
+				for (let i = 0, j = 0, u = 0, n = normals.length; i < n; j++, i += 3) {
+					if (usedIndices.has(j)) {
+						normalMap.set(j, u++);
+						await writer.writeLine('vn ' + normals[i] + ' ' + normals[i + 1] + ' ' + normals[i + 2]);
+					}
 				}
-			}
 
-			// UVs (all layers; index map built from the first layer only).
-			if (hasUV) {
-				for (let uvIndex = 0; uvIndex < layerCount; uvIndex++) {
-					const uv = uvLayers[uvIndex];
-					let prefix = 'vt';
-					if (uvIndex > 0)
-						prefix += (uvIndex + 1);
-
-					for (let i = 0, j = 0, u = 0, n = uv.length; i < n; j++, i += 2) {
+				// Vertex colours are deferred; see colorBlocks above.
+				if (colors) {
+					const block = new Float32Array(vertMap.size * 4);
+					let u = 0;
+					for (let i = 0, j = 0, n = colors.length; i < n; j++, i += 4) {
 						if (usedIndices.has(j)) {
-							if (uvIndex === 0)
-								uvMap.set(j, u++);
+							const di = u * 4;
+							block[di] = colors[i];
+							block[di + 1] = colors[i + 1];
+							block[di + 2] = colors[i + 2];
+							block[di + 3] = colors[i + 3];
+							u++;
+						}
+					}
 
-							const v = flipUVs ? (1 - uv[i + 1]) : uv[i + 1];
-							await writer.writeLine(prefix + ' ' + uv[i] + ' ' + v);
+					colorBlocks.push(block);
+					anyColors = true;
+				} else {
+					colorBlocks.push(vertMap.size);
+				}
+
+				// UVs (all layers; index map built from the first layer only).
+				if (hasUV) {
+					for (let uvIndex = 0; uvIndex < layerCount; uvIndex++) {
+						const uv = uvLayers[uvIndex];
+						let prefix = 'vt';
+						if (uvIndex > 0)
+							prefix += (uvIndex + 1);
+
+						for (let i = 0, j = 0, u = 0, n = uv.length; i < n; j++, i += 2) {
+							if (usedIndices.has(j)) {
+								if (uvIndex === 0)
+									uvMap.set(j, u++);
+
+								const v = flipUVs ? (1 - uv[i + 1]) : uv[i + 1];
+								await writer.writeLine(prefix + ' ' + uv[i] + ' ' + v);
+							}
 						}
 					}
 				}
+
+				// Faces, using global 1-based indices (local compacted + running base).
+				for (const mesh of meshes) {
+					await writer.writeLine('g ' + mesh.name);
+					await writer.writeLine('s 1');
+
+					if (mesh.matName)
+						await writer.writeLine('usemtl ' + mesh.matName);
+
+					const tris = mesh.triangles;
+					for (let i = 0, n = tris.length; i < n; i += 3) {
+						const a = tris[i], b = tris[i + 1], c = tris[i + 2];
+
+						const va = vertBase + vertMap.get(a) + 1;
+						const vb = vertBase + vertMap.get(b) + 1;
+						const vc = vertBase + vertMap.get(c) + 1;
+
+						const na = normalBase + normalMap.get(a) + 1;
+						const nb = normalBase + normalMap.get(b) + 1;
+						const nc = normalBase + normalMap.get(c) + 1;
+
+						const ua = hasUV ? uvBase + uvMap.get(a) + 1 : '';
+						const ub = hasUV ? uvBase + uvMap.get(b) + 1 : '';
+						const uc = hasUV ? uvBase + uvMap.get(c) + 1 : '';
+
+						await writer.writeLine('f ' + va + '/' + ua + '/' + na + ' ' + vb + '/' + ub + '/' + nb + ' ' + vc + '/' + uc + '/' + nc);
+					}
+				}
+
+				// Advance the global bases by the number of unique verts we emitted
+				// for this group (vertMap/normalMap/uvMap all share usedIndices size).
+				vertBase += vertMap.size;
+				normalBase += normalMap.size;
+				uvBase += uvMap.size;
 			}
 
-			// Faces, using global 1-based indices (local compacted + running base).
-			for (const mesh of meshes) {
-				await writer.writeLine('g ' + mesh.name);
-				await writer.writeLine('s 1');
-
-				if (mesh.matName)
-					await writer.writeLine('usemtl ' + mesh.matName);
-
-				const tris = mesh.triangles;
-				for (let i = 0, n = tris.length; i < n; i += 3) {
-					const a = tris[i], b = tris[i + 1], c = tris[i + 2];
-
-					const va = vertBase + vertMap.get(a) + 1;
-					const vb = vertBase + vertMap.get(b) + 1;
-					const vc = vertBase + vertMap.get(c) + 1;
-
-					const na = normalBase + normalMap.get(a) + 1;
-					const nb = normalBase + normalMap.get(b) + 1;
-					const nc = normalBase + normalMap.get(c) + 1;
-
-					const ua = hasUV ? uvBase + uvMap.get(a) + 1 : '';
-					const ub = hasUV ? uvBase + uvMap.get(b) + 1 : '';
-					const uc = hasUV ? uvBase + uvMap.get(c) + 1 : '';
-
-					await writer.writeLine('f ' + va + '/' + ua + '/' + na + ' ' + vb + '/' + ub + '/' + nb + ' ' + vc + '/' + uc + '/' + nc);
+			// Emit the buffered vertex colours, zero-filling groups that had
+			// none, so vc count and order always line up with the vertices.
+			if (anyColors) {
+				for (const block of colorBlocks) {
+					if (typeof block === 'number') {
+						for (let i = 0; i < block; i++)
+							await writer.writeLine('vc 0 0 0 0');
+					} else {
+						for (let i = 0, n = block.length; i < n; i += 4)
+							await writer.writeLine('vc ' + block[i] + ' ' + block[i + 1] + ' ' + block[i + 2] + ' ' + block[i + 3]);
+					}
 				}
 			}
-
-			// Advance the global bases by the number of unique verts we emitted
-			// for this group (vertMap/normalMap/uvMap all share usedIndices size).
-			vertBase += vertMap.size;
-			normalBase += normalMap.size;
-			uvBase += uvMap.size;
+		} finally {
+			// A failure mid-stream must not leak the file handle; without this
+			// an exception leaves a partial .obj open and looking complete.
+			writer.close();
 		}
-
-		writer.close();
 	}
 }
 

--- a/src/js/3D/writers/OBJWriter.js
+++ b/src/js/3D/writers/OBJWriter.js
@@ -247,6 +247,151 @@ class OBJWriter {
 
 		writer.close();
 	}
+
+	/**
+	 * Write the OBJ file one group at a time, never holding the whole model in
+	 * memory at once. Each group carries its own vertices/normals/uvs/colours and
+	 * its own meshes (whose triangle indices are group-local, i.e. zero-based
+	 * within that group's vertex block). This is the memory-safe path for very
+	 * large models (e.g. raid WMOs of several million vertices) where building a
+	 * single merged buffer plus every retained index array exhausts the V8 heap.
+	 *
+	 * Output is equivalent to write(): each group emits its used verts, normals,
+	 * uvs and (optional) colours, remapped to a compact local numbering, followed
+	 * by its faces. Vertex references in 'f' lines are global 1-based indices, so
+	 * a running offset is carried across groups. Groups are independent (WMO
+	 * groups never share vertices), so no cross-group dedup is needed or lost.
+	 *
+	 * @param {Iterable|AsyncIterable} groups - yields { verts, normals, uvs,
+	 *   colors, meshes, flipUVs } where meshes is [{ name, triangles, matName }]
+	 *   with triangles zero-based within this group's verts.
+	 * @param {boolean} overwrite
+	 */
+	async writeStreamingGroups(groups, overwrite = true) {
+		if (!overwrite && await generics.fileExists(this.out))
+			return;
+
+		await generics.createDirectory(path.dirname(this.out));
+		const writer = new FileWriter(this.out);
+
+		await writer.writeLine('# Exported using wow.export v' + constants.VERSION);
+		await writer.writeLine('o ' + this.name);
+
+		if (this.mtl)
+			await writer.writeLine('mtllib ' + this.mtl);
+
+		// Running counts of already-emitted verts / normals / uvs / colours so
+		// each group's face indices resolve to the correct global 1-based value.
+		let vertBase = 0;
+		let normalBase = 0;
+		let uvBase = 0;
+
+		for await (const group of groups) {
+			const verts = group.verts;
+			const normals = group.normals;
+			const uvLayers = group.uvs ?? [];
+			const colors = group.colors ?? null;
+			const meshes = group.meshes ?? [];
+			const flipUVs = group.flipUVs ?? this.flip_uvs;
+
+			const layerCount = uvLayers.length;
+			const hasUV = layerCount > 0;
+
+			// Determine which of this group's vertices are actually referenced
+			// by a face, mirroring write()'s culling so output stays identical.
+			const usedIndices = new Set();
+			for (const mesh of meshes) {
+				const tris = mesh.triangles;
+				for (let i = 0, n = tris.length; i < n; i++)
+					usedIndices.add(tris[i]);
+			}
+
+			// Local (group) index -> compacted position within the emitted block.
+			const vertMap = new Map();
+			const normalMap = new Map();
+			const uvMap = new Map();
+
+			// Verts.
+			for (let i = 0, j = 0, u = 0, n = verts.length; i < n; j++, i += 3) {
+				if (usedIndices.has(j)) {
+					vertMap.set(j, u++);
+					await writer.writeLine('v ' + verts[i] + ' ' + verts[i + 1] + ' ' + verts[i + 2]);
+				}
+			}
+
+			// Normals.
+			for (let i = 0, j = 0, u = 0, n = normals.length; i < n; j++, i += 3) {
+				if (usedIndices.has(j)) {
+					normalMap.set(j, u++);
+					await writer.writeLine('vn ' + normals[i] + ' ' + normals[i + 1] + ' ' + normals[i + 2]);
+				}
+			}
+
+			// Vertex colours (non-standard, used by the wow.export Blender addon).
+			if (colors) {
+				for (let i = 0, j = 0, n = colors.length; i < n; j++, i += 4) {
+					if (usedIndices.has(j))
+						await writer.writeLine('vc ' + colors[i] + ' ' + colors[i + 1] + ' ' + colors[i + 2] + ' ' + colors[i + 3]);
+				}
+			}
+
+			// UVs (all layers; index map built from the first layer only).
+			if (hasUV) {
+				for (let uvIndex = 0; uvIndex < layerCount; uvIndex++) {
+					const uv = uvLayers[uvIndex];
+					let prefix = 'vt';
+					if (uvIndex > 0)
+						prefix += (uvIndex + 1);
+
+					for (let i = 0, j = 0, u = 0, n = uv.length; i < n; j++, i += 2) {
+						if (usedIndices.has(j)) {
+							if (uvIndex === 0)
+								uvMap.set(j, u++);
+
+							const v = flipUVs ? (1 - uv[i + 1]) : uv[i + 1];
+							await writer.writeLine(prefix + ' ' + uv[i] + ' ' + v);
+						}
+					}
+				}
+			}
+
+			// Faces, using global 1-based indices (local compacted + running base).
+			for (const mesh of meshes) {
+				await writer.writeLine('g ' + mesh.name);
+				await writer.writeLine('s 1');
+
+				if (mesh.matName)
+					await writer.writeLine('usemtl ' + mesh.matName);
+
+				const tris = mesh.triangles;
+				for (let i = 0, n = tris.length; i < n; i += 3) {
+					const a = tris[i], b = tris[i + 1], c = tris[i + 2];
+
+					const va = vertBase + vertMap.get(a) + 1;
+					const vb = vertBase + vertMap.get(b) + 1;
+					const vc = vertBase + vertMap.get(c) + 1;
+
+					const na = normalBase + normalMap.get(a) + 1;
+					const nb = normalBase + normalMap.get(b) + 1;
+					const nc = normalBase + normalMap.get(c) + 1;
+
+					const ua = hasUV ? uvBase + uvMap.get(a) + 1 : '';
+					const ub = hasUV ? uvBase + uvMap.get(b) + 1 : '';
+					const uc = hasUV ? uvBase + uvMap.get(c) + 1 : '';
+
+					await writer.writeLine('f ' + va + '/' + ua + '/' + na + ' ' + vb + '/' + ub + '/' + nb + ' ' + vc + '/' + uc + '/' + nc);
+				}
+			}
+
+			// Advance the global bases by the number of unique verts we emitted
+			// for this group (vertMap/normalMap/uvMap all share usedIndices size).
+			vertBase += vertMap.size;
+			normalBase += normalMap.size;
+			uvBase += uvMap.size;
+		}
+
+		writer.close();
+	}
 }
 
 module.exports = OBJWriter;

--- a/src/js/3D/writers/OBJWriter.js
+++ b/src/js/3D/writers/OBJWriter.js
@@ -8,6 +8,22 @@ const constants = require('../../constants');
 const generics = require('../../generics');
 const FileWriter = require('../../file-writer');
 
+/**
+ * Concatenate two numeric sequences into a single Float32Array, allocating the
+ * result once and copying in place. Avoids the [...a, ...b] spread that builds a
+ * temporary JS array of every element before rebuilding a typed array - a triple
+ * copy that exhausts the heap on large (e.g. raid-sized) geometry.
+ * @param {Float32Array|Array} a
+ * @param {Float32Array|Array} b
+ * @returns {Float32Array}
+ */
+function concatFloats(a, b) {
+	const out = new Float32Array(a.length + b.length);
+	out.set(a, 0);
+	out.set(b, a.length);
+	return out;
+}
+
 class OBJWriter {
 	/**
 	 * Construct a new OBJWriter instance.
@@ -100,20 +116,12 @@ class OBJWriter {
 		this.vertex_offset = current_vertex_count;
 
 		// append vertices
-		if (verts) {
-			if (Array.isArray(this.verts))
-				this.verts = [...this.verts, ...verts];
-			else
-				this.verts = Float32Array.from([...this.verts, ...verts]);
-		}
+		if (verts)
+			this.verts = concatFloats(this.verts, verts);
 
 		// append normals
-		if (normals) {
-			if (Array.isArray(this.normals))
-				this.normals = [...this.normals, ...normals];
-			else
-				this.normals = Float32Array.from([...this.normals, ...normals]);
-		}
+		if (normals)
+			this.normals = concatFloats(this.normals, normals);
 
 		// append uvs (match layer count)
 		if (uvArrays) {
@@ -122,12 +130,8 @@ class OBJWriter {
 					this.uvs.push([]);
 
 				const uv = uvArrays[i];
-				if (uv) {
-					if (Array.isArray(this.uvs[i]))
-						this.uvs[i] = [...this.uvs[i], ...uv];
-					else
-						this.uvs[i] = Float32Array.from([...this.uvs[i], ...uv]);
-				}
+				if (uv)
+					this.uvs[i] = concatFloats(this.uvs[i], uv);
 			}
 		}
 	}


### PR DESCRIPTION
Exporting a very large WMO (e.g. a raid at several million triangles) exhausts the V8 renderer heap and crashes the app. There are three separate causes; this PR addresses all of them, applied and re-tested in order.

**1. Geometry buffers were plain JS Arrays**

The OBJ/GLTF/STL paths pre-allocated `new Array(nInd * 3)` for vertices, normals and each UV/colour layer. On V8 an index-assigned float Array holds boxed doubles at ~8 bytes/element plus overhead; a raid's tens of millions of elements across those buffers is multiple GB. Switched to `Float32Array` (4 bytes/element, no boxing, zero-initialised).

**2. `OBJWriter.appendGeometry` concatenated via spread**

`Float32Array.from([...this.verts, ...verts])` builds a temporary JS array of every element before rebuilding a typed array — a triple copy per append, quadratic over a map's worth of WMOs. Replaced with a `concatFloats` helper that allocates once and copies with `.set()`.

**3. The model was still fully resident during export**

Even with typed arrays, `exportAsOBJ` merged every group into one buffer, and separately `WMOLoader.getGroup` caches every group it loads and never evicts. Walking all groups to export therefore left the entire model resident twice over — and because a map export re-runs the WMO exporter once per referencing ADT tile, the loader cache compounded across passes, still OOMing on a raid.

Two changes here:

- Added `OBJWriter.writeStreamingGroups()`. It writes the model one group at a time — each group's used verts/normals/UVs/colours emitted with a compact local numbering, then its faces, with a running global offset carried across groups. `exportAsOBJ` feeds it groups via an async generator, so peak memory is one group rather than the whole model.
- The generator drops each group's loader-cache slot (`wmo.groups[i] = null`) once the writer has consumed it; `getGroup` transparently reloads from CASC if a later pass or the metadata writer needs the group again. The metadata-JSON pass, which runs after the geometry write, re-fetches per group and releases again.

Scoped to the merged `exportAsOBJ` path (which constructs its own `OBJWriter` per WMO). The glTF/STL paths, `exportGroupsAsSeparateOBJ`, and the shared `write()` used by the M2 and ADT exporters are untouched.

**Output**

Equivalent to the previous merged-buffer write. Line ordering differs — the streaming path interleaves each group's vertex block with its faces rather than all vertices before all faces — which is valid OBJ, since indices reference declaration order. Vertex culling (dropping vertices no face references) is preserved. Verified by parsing both outputs and confirming every face resolves to identical vertices, UVs, normals and material.

**Testing**

Exported the full Ulatek raid (12.1) as part of a map export on Windows. Before these changes the export reproducibly died with `V8 javascript OOM (CALL_AND_RETRY_LAST)` in the renderer process. After them the export completed: 4/4 ADT tiles, 23 WMO OBJ passes over the raid and its pieces, with the renderer holding a flat ~1.5 GB throughout the geometry work and no OOM.