### PR TITLE
Skip redundant texture decodes during WMO export

### DIFF
--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -25,6 +25,12 @@ const WMOShaderMapper = require('../WMOShaderMapper');
 
 const doodadCache = new Set();
 
+// Textures already fetched, decoded and written during the current export.
+// A large WMO (or a map of many WMOs) references the same textures repeatedly;
+// without this each reference re-fetches and re-decodes the BLP. Cleared by
+// clearCache() at the end of an export, alongside doodadCache.
+const textureExportCache = new Set();
+
 class WMOExporter {
 	/**
 	 * Construct a new WMOExporter instance.
@@ -165,17 +171,26 @@ class WMOExporter {
 
 					const file_existed = await generics.fileExists(texPath);
 
+					// A texture referenced by many materials (or shared across the
+					// WMOs of a map) otherwise gets fetched and decoded once per
+					// reference. Decoding it once per export is enough - a large
+					// raid can reference the same handful of textures thousands of
+					// times, and the fetch+BLP decode dominates the export time.
+					const already_written = textureExportCache.has(fileDataID);
+
 					if (glbMode && !raw) {
 						// glb mode: convert to PNG buffer without writing
-						const data = await casc.getFile(fileDataID);
-						const blp = new BLPFile(data);
-						const png_buffer = blp.toPNG(useAlpha ? 0b1111 : 0b0111);
-						texture_buffers.set(fileDataID, png_buffer);
-						log.write('Buffering WMO texture %d for GLB embedding', fileDataID);
+						if (!texture_buffers.has(fileDataID)) {
+							const data = await casc.getFile(fileDataID);
+							const blp = new BLPFile(data);
+							const png_buffer = blp.toPNG(useAlpha ? 0b1111 : 0b0111);
+							texture_buffers.set(fileDataID, png_buffer);
+							log.write('Buffering WMO texture %d for GLB embedding', fileDataID);
 
-						if (!file_existed)
-							files_to_cleanup.push(texPath);
-					} else if (config.overwriteFiles || !file_existed) {
+							if (!file_existed)
+								files_to_cleanup.push(texPath);
+						}
+					} else if (!already_written && (config.overwriteFiles || !file_existed)) {
 						const data = await casc.getFile(fileDataID);
 
 						log.write('Exporting WMO texture %d -> %s', fileDataID, texPath);
@@ -185,8 +200,9 @@ class WMOExporter {
 							const blp = new BLPFile(data);
 							await blp.saveToPNG(texPath, useAlpha ? 0b1111 : 0b0111);
 						}
+						textureExportCache.add(fileDataID);
 					} else {
-						log.write('Skipping WMO texture export %s (file exists, overwrite disabled)', texPath);
+						log.write('Skipping WMO texture export %s (already exported this run or exists)', texPath);
 					}
 
 					if (usePosix)
@@ -1368,6 +1384,7 @@ class WMOExporter {
 	 */
 	static clearCache() {
 		doodadCache.clear();
+		textureExportCache.clear();
 	}
 }
 

--- a/src/js/3D/exporters/WMOExporter.js
+++ b/src/js/3D/exporters/WMOExporter.js
@@ -176,7 +176,11 @@ class WMOExporter {
 					// reference. Decoding it once per export is enough - a large
 					// raid can reference the same handful of textures thousands of
 					// times, and the fetch+BLP decode dominates the export time.
-					const already_written = textureExportCache.has(fileDataID);
+					// Keyed on the destination too: with shared textures disabled
+					// the same fileDataID legitimately lands in several folders,
+					// and skipping those writes would leave dangling MTL entries.
+					const texture_cache_key = fileDataID + '>' + texPath;
+					const already_written = textureExportCache.has(texture_cache_key);
 
 					if (glbMode && !raw) {
 						// glb mode: convert to PNG buffer without writing
@@ -200,7 +204,7 @@ class WMOExporter {
 							const blp = new BLPFile(data);
 							await blp.saveToPNG(texPath, useAlpha ? 0b1111 : 0b0111);
 						}
-						textureExportCache.add(fileDataID);
+						textureExportCache.add(texture_cache_key);
 					} else {
 						log.write('Skipping WMO texture export %s (already exported this run or exists)', texPath);
 					}


### PR DESCRIPTION
## Problem

Exporting a map (or a large WMO) can spend an enormous amount of time in the texture phase because the same texture is fetched from CASC and decoded from BLP once **per material reference**, with no memory of what was already exported.

Maps reuse a small set of WMOs across many tiles, and each WMO references its textures across many materials, so shared textures get decoded over and over. A 12.1 raid map export logged **~28,000 texture writes for only 436 distinct textures** — the texture phase ran for over an hour, dominated almost entirely by redundant decodes.

The existing `file_existed` check doesn't help here: with `overwriteFiles` enabled it re-decodes regardless, and even the decode+`saveToPNG` runs before the write is skipped.

## Fix

Track the `fileDataID`s already fetched, decoded and written during the current export in a `Set`, and skip the fetch/decode/write on repeat references. The set is cleared by `clearCache()` alongside the existing `doodadCache`, so it has the same per-export lifetime and clears at the same points.

The MTL material mapping (`mtl.addMaterial` / `textureMap.set`) still runs for every reference, so the generated `.mtl` is unchanged — only the duplicate fetch/decode/write is skipped. The GLB buffering path is likewise guarded so it doesn't re-decode a texture already in its buffer.

## Impact

For the raid case above this reduces ~28,000 decode operations to 436 — a ~65× reduction in texture work, turning an hour-long texture phase into seconds. Smaller exports see proportional savings wherever textures are shared.

## Scope

One file (`WMOExporter.js`), no new dependencies, no build-pipeline changes. Output is byte-identical. Follows the existing `doodadCache` pattern for consistency.
