### PR TITLE
Fix WMO textures importing into Blender as black

### DIFF
--- a/addons/blender/io_scene_wowobj/import_wowobj.py
+++ b/addons/blender/io_scene_wowobj/import_wowobj.py
@@ -858,6 +858,14 @@ def loadImage(textureLocation):
         loadedImage = bpy.data.images.load(textureLocation)
         loadedImage.name = imageName
 
+        # Game textures pack independent data into their channels; many opaque
+        # ones ship with an unused alpha channel that sits at zero. Blender's
+        # default straight-alpha handling multiplies the colour by alpha when
+        # sampling, which turns those textures solid black. Channel-packed
+        # leaves the colour untouched and keeps the alpha readable for the
+        # material paths that use it as a mask or height source.
+        loadedImage.alpha_mode = 'CHANNEL_PACKED'
+
     return bpy.data.images[imageName]
 
 def createStandardMaterial(materialName, textureLocation, blendMode, createEmissive, extension_mode='REPEAT'):


### PR DESCRIPTION
WMO surfaces import into Blender rendering solid black even though the exported textures are fine. On the dungeon this was found on, the texture covering a third of the model has a good colour channel and an all-zero alpha channel.

### Cause

Opaque game textures often carry an unused alpha channel that sits at zero. Blender defaults loaded images to `STRAIGHT` alpha, which multiplies the colour by alpha when sampling — so a texture with good colour and zero alpha reaches the shader as black.

Rendering the affected texture as flat emission makes it plain:

| alpha_mode | sampled result |
|---|---|
| `STRAIGHT` (default) | black, median 0/255 |
| `CHANNEL_PACKED` | the actual art, median 88/255 |

Several material builders in `import_wowobj.py` already set `CHANNEL_PACKED` on the images they load, but the paths that go through `loadImage` without it — including the WMO shader 20 builder — kept the default and rendered black.

### Change

`loadImage` sets `alpha_mode = 'CHANNEL_PACKED'` on every image it loads. This uses the colour as-is and — unlike `NONE` — keeps the alpha channel readable for the paths that use it as a blend mask or height source. One shared load point, all builders covered.

### Verification

- Flat-emission A/B render of the zero-alpha texture: `STRAIGHT` → black, `CHANNEL_PACKED` → correct colour.
- Fresh import of the affected dungeon WMO and a terrain tile through the patched addon: previously-black surfaces render with their actual art.
