### PR TITLE
(Potential) Worgen Visage Fix

### DIFF
--- a/src/js/modules/tab_characters.js
+++ b/src/js/modules/tab_characters.js
@@ -1295,7 +1295,7 @@ async function apply_import_data(core, data, source) {
 
 		// worgen/dracthyr visage
 		if (race_id == 22 && core.view.chrImportLoadVisage)
-			race_id = 23;
+			race_id = 1;
 
 		if (race_id == 52 && core.view.chrImportLoadVisage)
 			race_id = 75;


### PR DESCRIPTION
I can't get this to build for the life of me, but changing race_id = 23 to race_id = 1 for the Worgen visage should theoretically fix the issue where Worgen visages don't export properly; race_id 23 is for the Gilnean models, while 1 is for the human models. I believe 23 is deprecated, hence it not exporting properly. Thank you :]